### PR TITLE
Stabilize auth and room voice client flows

### DIFF
--- a/docs/superpowers/specs/2026-04-05-messages-sidebar-and-friend-removal-design.md
+++ b/docs/superpowers/specs/2026-04-05-messages-sidebar-and-friend-removal-design.md
@@ -1,0 +1,213 @@
+# Messages Sidebar And Friend Removal Design
+
+## Summary
+
+This spec covers two related UX changes:
+
+1. Add explicit friend removal on the friends page.
+2. Add a `Messages` section to the lower-left sidebar that shows only existing direct conversations.
+
+It also removes the dependency on the legacy global WebSocket flow for normal personal messaging navigation, because that flow is incompatible with the current Go backend and produces authorization errors.
+
+## Goals
+
+- Users can remove a friend directly from the `Friends` page.
+- Sidebar shows only users who already have a direct message history with the current user.
+- Clicking a sidebar conversation opens the existing direct chat page.
+- The sidebar/messages flow does not rely on the legacy WireChat protocol.
+- Normal app navigation no longer triggers the `Authorization header missing` error for the personal chat path.
+
+## Non-Goals
+
+- Reintroducing old incoming direct-call signaling.
+- Reworking room voice behavior.
+- Deleting chat history when a friend is removed.
+- Adding unread counts, typing indicators, or search in messages.
+
+## Current Problems
+
+### Friend Removal
+
+The backend already supports `DELETE /api/friends/remove`, but the current friends UI does not expose a removal action.
+
+### Messages Sidebar
+
+The sidebar currently has `Pinned Friends`, but no separate direct message list. The user wants a dedicated `Messages` section that contains only conversations with existing chat history.
+
+### Authorization Errors
+
+The app still mounts the legacy global `WebSocketContext`. That context is built for a different signaling/chat contract and attempts to connect during normal app usage. On the current backend this causes repeated authorization-related failures and is unrelated to the newer direct chat page implementation.
+
+## Proposed UX
+
+### Friends Page
+
+Each friend card will have three actions:
+
+- Open direct chat
+- Open private voice room
+- Remove friend
+
+Removal behavior:
+
+- Clicking `Remove` sends the existing backend request.
+- On success, the friend disappears from the current list immediately.
+- A success message is shown.
+- If the user had an existing direct chat history with that person, the chat history is not deleted automatically.
+
+### Sidebar
+
+A new `Messages` section will appear near the lower-left area of the sidebar.
+
+The list contains only direct conversations that already exist in message history.
+
+Each item shows:
+
+- Username
+- Optional display name fallback if available
+- Last message preview
+- Last message timestamp
+
+Clicking an item navigates to `/chat/:friendUserId`.
+
+### Empty State
+
+If there are no existing conversations, the `Messages` section shows a short empty-state message instead of listing all friends.
+
+## Backend API
+
+### Existing Endpoint Reused
+
+Friend removal continues to use:
+
+- `DELETE /api/friends/remove`
+
+Payload:
+
+```json
+{ "friend_username": "alice" }
+```
+
+### New Endpoint Required
+
+Add:
+
+- `GET /api/chat/conversations`
+
+Protected endpoint. It returns the direct conversation list for the authenticated user.
+
+Response shape:
+
+```json
+{
+  "conversations": [
+    {
+      "user_id": "friend-uuid",
+      "username": "alice",
+      "name": "Alice",
+      "last_message": "hello",
+      "last_message_at": "2026-04-05T12:00:00Z"
+    }
+  ]
+}
+```
+
+Behavior:
+
+- Find all messages where current user is sender or receiver.
+- Group by the other participant.
+- For each participant, return the latest message text and timestamp.
+- Join against `users` to return `username` and `name`.
+- Sort by `last_message_at` descending.
+
+## Client Architecture
+
+### New Sidebar Messages Data Flow
+
+Add a small client API layer for:
+
+- `fetchConversations(token)`
+
+The sidebar will load this list after authentication and render it without depending on the legacy global WebSocket context.
+
+### Friend Removal Flow
+
+Use the existing client service for removal or extend it if needed so that the `Friends` page can call:
+
+- `removeFriend(friend.username, token)`
+
+Then refresh or optimistically update local friends state.
+
+### WebSocket Scope
+
+The legacy `WebSocketContext` should no longer be a required global app dependency for the personal messaging path.
+
+Target behavior:
+
+- Sidebar conversation list uses plain HTTP.
+- Direct chat page continues using the newer direct chat implementation.
+- Normal app boot should not open the old incompatible personal chat socket automatically.
+
+The safest implementation is to remove global mounting of the legacy context from the main app tree unless another still-working feature depends on it. If any remaining feature still depends on it, scope it only to those screens instead of the whole application.
+
+## Implementation Outline
+
+### Backend
+
+1. Add `GET /api/chat/conversations`.
+2. Query distinct conversation partners with latest message metadata.
+3. Return stable JSON payload documented above.
+
+### Client
+
+1. Add messages sidebar service/types.
+2. Render `Messages` block in sidebar.
+3. Add `Remove` button to friend cards.
+4. Stop relying on the legacy global `WebSocketContext` for personal chat navigation.
+
+## Risks
+
+### Legacy Call Features
+
+Some old call UI may still reference the legacy WebSocket/call context. Removing or scoping the old context must be done carefully so room voice work remains intact.
+
+### Conversation Identity
+
+The sidebar must use UUID `user_id`, not numeric DB IDs, because direct chat routes and backend message history are UUID-based.
+
+### Message Preview Accuracy
+
+The backend query for latest message per conversation must be deterministic and sorted correctly, otherwise sidebar order will feel broken.
+
+## Testing
+
+### Friend Removal
+
+1. Add two users as friends.
+2. Remove one from the friends page.
+3. Confirm the friend disappears from the list.
+4. Confirm a direct chat page, if previously opened, can still render history.
+
+### Sidebar Messages
+
+1. Send at least one message between two users.
+2. Reload the app.
+3. Confirm the conversation appears in `Messages`.
+4. Confirm users without message history do not appear there.
+5. Click a conversation and confirm chat opens with the correct user UUID.
+
+### Authorization Regression
+
+1. Open the app after login.
+2. Navigate between home, friends, and chat.
+3. Confirm the previous `Authorization header missing` error no longer appears for the personal chat path.
+
+## Scope Check
+
+This spec is intentionally limited to:
+
+- friend removal
+- sidebar conversation list
+- removal of the legacy personal-chat bootstrap dependency
+
+It is small enough for a single implementation pass.

--- a/docs/superpowers/specs/2026-04-05-room-voice-design.md
+++ b/docs/superpowers/specs/2026-04-05-room-voice-design.md
@@ -127,25 +127,25 @@ The implementation needs a room-scoped voice/session API rather than an ad hoc r
 
 Recommended backend contract:
 
-- `GET /rooms/:id/state`
-- `POST /rooms/:id/voice/join`
-- `POST /rooms/:id/voice/leave`
+- `GET /api/rooms/:id/state`
+- `POST /api/rooms/:id/voice/join`
+- `POST /api/rooms/:id/voice/leave`
 
-`GET /rooms/:id/state` should return:
+`GET /api/rooms/:id/state` should return:
 
 - room metadata
 - room members
 - voice participants
 - per-participant media state
 
-`POST /rooms/:id/voice/join` should return:
+`POST /api/rooms/:id/voice/join` should return:
 
 - media server URL
 - media access token
 - stable room media identity
 - participant identity
 
-`POST /rooms/:id/voice/leave` should:
+`POST /api/rooms/:id/voice/leave` should:
 
 - remove the user from room voice presence
 - terminate the user's room media session

--- a/docs/superpowers/specs/2026-04-05-room-voice-design.md
+++ b/docs/superpowers/specs/2026-04-05-room-voice-design.md
@@ -1,0 +1,292 @@
+# Room Voice Design
+
+## Summary
+
+This document defines a Discord-like room model for `gocall_client`, where a room is a persistent space and voice participation is a separate, explicit action. A user can enter a room without joining voice. Voice, camera, and screen sharing are activated only after the user presses an explicit button.
+
+The design replaces the current "start a room call" mental model with a room-scoped voice presence model:
+
+- entering a room does not auto-connect media
+- voice connection is room-bound and explicit
+- leaving the room page does not automatically leave voice
+- only an explicit `Leave Voice` action disconnects media
+
+## Goals
+
+- Support Discord-like room behavior for voice participation.
+- Allow a user to sit alone in a room voice channel without errors.
+- Separate room presence from voice presence.
+- Keep microphone, camera, and screen share as independent toggles after joining voice.
+- Preserve an active room voice session when navigating away from the room page.
+- Reuse existing client LiveKit/media controls where possible.
+
+## Non-Goals
+
+- Reworking direct calls in this design.
+- Designing full moderator permissions or stage-channel semantics.
+- Background recording, voice activity analytics, or push-to-talk.
+- Solving room text chat protocol differences in this document.
+
+## Current State
+
+The current client already has:
+
+- room pages
+- a LiveKit wrapper
+- room-oriented call UI controls
+- a global call context
+
+However, the active room flow still assumes a temporary call/session model:
+
+- users open a room page
+- a call is created separately
+- room voice state is treated as a call lifecycle rather than a persistent room-scoped presence
+
+The current Go backend in this workspace does not expose the `calls` and room-media endpoints expected by the client. That mismatch must be resolved in implementation by either restoring the original backend contract or adapting the client to the actual signaling/media backend.
+
+## User Experience
+
+### Entering a Room
+
+When a user opens a room page, they enter the room as a participant in the space, but not in voice.
+
+The room page should show:
+
+- room metadata
+- room members
+- current voice participants
+- media state indicators for voice participants
+
+The room page must not request microphone, camera, or screen permissions on entry.
+
+### Joining Voice
+
+The room page includes a primary explicit action:
+
+- `Join Voice`
+
+When pressed:
+
+- the client requests room-scoped media credentials
+- the client joins the room voice session
+- the user becomes visible in the voice participant list
+- microphone/camera remain under explicit user control
+
+### In Voice
+
+After joining voice, the user can:
+
+- mute/unmute microphone
+- enable/disable camera
+- start/stop screen share
+- remain in the voice channel while alone
+- navigate elsewhere in the app without being disconnected
+
+### Leaving Voice
+
+The room page and any global persistent voice UI include:
+
+- `Leave Voice`
+
+This is the only action that disconnects room voice participation.
+
+Leaving the page or navigating through the app must not implicitly trigger `Leave Voice`.
+
+## Room Model
+
+Each room has two distinct states:
+
+### Room Presence
+
+Room presence means the user has opened the room and is participating in the room as an application space.
+
+This includes:
+
+- seeing room information
+- seeing member lists
+- seeing who is currently in voice
+
+Room presence does not imply active media.
+
+### Voice Presence
+
+Voice presence means the user has explicitly joined the room voice session.
+
+This includes:
+
+- active membership in the room voice channel
+- optional microphone publication
+- optional camera publication
+- optional screen-share publication
+
+Voice presence can outlive the visible room page session.
+
+## Required Backend Contract
+
+The implementation needs a room-scoped voice/session API rather than an ad hoc room call creation flow.
+
+Recommended backend contract:
+
+- `GET /rooms/:id/state`
+- `POST /rooms/:id/voice/join`
+- `POST /rooms/:id/voice/leave`
+
+`GET /rooms/:id/state` should return:
+
+- room metadata
+- room members
+- voice participants
+- per-participant media state
+
+`POST /rooms/:id/voice/join` should return:
+
+- media server URL
+- media access token
+- stable room media identity
+- participant identity
+
+`POST /rooms/:id/voice/leave` should:
+
+- remove the user from room voice presence
+- terminate the user's room media session
+- keep room membership/page state intact
+
+This backend can be implemented directly in the Go API or proxied to the signaling/media service used in the original project.
+
+## Client State Model
+
+The client should track room voice state independently from page visibility.
+
+### Persistent Global Voice State
+
+The global call context should evolve into a room voice session context capable of surviving route transitions.
+
+At minimum it should track:
+
+- active room ID
+- active room name
+- whether the user is in room voice
+- whether mic is enabled
+- whether camera is enabled
+- whether screen share is enabled
+- connected participants and their media state
+
+### Route-Level Room State
+
+The room page should read global room voice state and render room-specific controls.
+
+The room page must not own the lifetime of the voice connection. It only reflects and manipulates it.
+
+### Single Active Voice Session
+
+Initial scope should support one active voice session at a time.
+
+Rules:
+
+- joining voice in another room should either be blocked or first require leaving the current room voice
+- direct calls and room voice should not coexist in the initial implementation
+
+## UI Design
+
+### Room Header
+
+The room header should show:
+
+- room title
+- room presence information
+- voice participant count
+- `Join Voice` or `Leave Voice` depending on current state
+
+### Main Room Area
+
+The main area should show:
+
+- video tiles for participants publishing camera or screen
+- avatar tiles for users in voice without video
+- a stable empty/solo state when only one participant is present
+
+### Controls
+
+When in voice, controls should include:
+
+- microphone toggle
+- camera toggle
+- screen share toggle
+- leave voice button
+
+These controls should remain available both in the room page and in a global persistent mini-bar so the user can leave voice from elsewhere in the app.
+
+## Navigation Rules
+
+- Opening a room page does not join voice.
+- Leaving a room page does not leave voice.
+- Returning to the room page should rehydrate the current room voice UI if the user is still connected.
+- Explicit `Leave Voice` ends the room voice session.
+
+## Error Handling
+
+### Join Voice Failures
+
+If joining voice fails:
+
+- keep the user in room presence
+- show an actionable error
+- do not mark the user as in voice
+
+### Permission Failures
+
+If mic/camera/screen permission is denied:
+
+- keep the voice session active if the base connection succeeded
+- only disable the affected media capability
+- present a clear local error state
+
+### Solo Participant State
+
+If the user is alone in voice:
+
+- keep the session stable
+- show a normal waiting state
+- do not disconnect or degrade controls
+
+## Testing Plan
+
+### Core Scenarios
+
+1. Open a room and do not press `Join Voice`.
+2. Press `Join Voice` and connect to room voice.
+3. Stay alone in voice without errors.
+4. Toggle microphone on and off.
+5. Toggle camera on and off.
+6. Start and stop screen share.
+7. Navigate away from the room page while remaining connected.
+8. Return to the room page and verify rehydrated room voice UI.
+9. Press `Leave Voice` from the room page.
+10. Press `Leave Voice` from a global persistent voice bar.
+
+### Regression Risks
+
+- current room page assumes a call lifecycle tied to the page
+- current call context assumes call endpoints that are not present in the local Go backend
+- current client may need separation between direct-call state and room-voice state
+
+## Recommended Implementation Order
+
+1. Align backend or signaling contract for room-scoped voice join/leave/state.
+2. Refactor global call state into persistent room voice session state.
+3. Update room page to render `Join Voice` / `Leave Voice`.
+4. Prevent route changes from tearing down room voice.
+5. Add persistent global mini-bar for active room voice.
+6. Reconnect room page UI to the persistent room voice state.
+7. Verify solo, multi-user, and navigation scenarios.
+
+## Open Decisions
+
+For the agreed scope of this design, these decisions are fixed:
+
+- joining voice is explicit
+- leaving the room page does not disconnect voice
+- leaving voice is explicit
+- camera and screen share are supported after voice join
+
+No unresolved product ambiguity remains for the first implementation slice.

--- a/docs/superpowers/specs/2026-04-07-screen-share-separate-tile-design.md
+++ b/docs/superpowers/specs/2026-04-07-screen-share-separate-tile-design.md
@@ -1,0 +1,140 @@
+# Screen Share Separate Tile Design
+
+## Summary
+
+This spec defines the next room voice UI step: screen sharing must appear as a separate tile, without replacing the user's normal participant tile.
+
+The goal is to support the following model:
+
+- a participant remains visible as a normal voice/camera tile
+- an active screen share from that same participant appears as an additional tile
+- camera and screen share can coexist visually
+
+## Goals
+
+- Keep the participant's normal tile visible while screen sharing.
+- Render screen share as its own tile in the room grid.
+- Allow a participant to have both camera and screen share active at the same time.
+- Remove only the screen-share tile when sharing stops.
+
+## Non-Goals
+
+- Reworking room membership or voice lifecycle.
+- Changing authentication or room voice bootstrap behavior.
+- Adding screen-share pinning, focus mode, or presenter layouts.
+
+## Current Problem
+
+The current client media model collapses camera and screen share into a single `videoTrack` field. That means:
+
+- screen share can replace camera in the UI
+- the room grid cannot show both sources simultaneously
+- the client cannot cleanly represent the difference between a participant tile and a screen-share tile
+
+## Target Behavior
+
+### Participant Tile
+
+Each participant in room voice keeps a normal tile:
+
+- avatar when camera is off
+- camera video when camera is on
+- mic/camera indicators
+- no screen-share takeover
+
+### Screen Share Tile
+
+When a participant starts sharing their screen:
+
+- a new separate tile appears in the grid
+- the participant's normal tile remains visible
+- the screen-share tile shows only the shared screen
+- the tile should be labeled clearly, for example `username is sharing`
+
+When screen sharing stops:
+
+- only the screen-share tile disappears
+- the participant tile remains unchanged
+
+## Client State Model
+
+The client media state must represent camera and screen share independently.
+
+### Required `ParticipantInfo` Shape
+
+Instead of a single combined `videoTrack`, participant state should expose:
+
+- `cameraTrack`
+- `screenShareTrack`
+- `audioTrack`
+- `isCameraOff`
+- `isMuted`
+
+This allows the UI to render camera and screen share at the same time.
+
+## Rendering Model
+
+The room grid should be derived from two view-model item types:
+
+### 1. Participant Tile Item
+
+Represents the participant identity and optional camera.
+
+### 2. Screen Share Tile Item
+
+Represents the participant's active shared screen.
+
+The rendered grid becomes:
+
+- all participant tiles
+- plus all active screen-share tiles
+
+These are separate items, even if both belong to the same person.
+
+## UI Rules
+
+- Camera tile and screen-share tile must be visually distinct.
+- The participant tile keeps the user's identity, status icons, and avatar/camera.
+- The screen-share tile is clearly labeled as a screen share.
+- Screen-share tiles should not silently replace participant tiles.
+
+## Error Handling
+
+- If screen sharing fails to start, no screen-share tile should appear.
+- If screen sharing stops unexpectedly, remove only the screen-share tile.
+- If camera and screen share are both active, failure in one must not tear down the other.
+
+## Testing
+
+1. Join room voice with no camera and no screen share.
+   Expectation: only normal participant tile.
+2. Enable camera only.
+   Expectation: participant tile shows camera.
+3. Enable screen share only.
+   Expectation:
+   - participant tile remains visible
+   - new screen-share tile appears
+4. Enable both camera and screen share.
+   Expectation:
+   - participant tile shows camera
+   - separate screen-share tile appears
+5. Disable screen share while camera remains on.
+   Expectation:
+   - screen-share tile disappears
+   - camera tile remains
+6. Disable camera while screen share remains on.
+   Expectation:
+   - participant tile falls back to avatar
+   - screen-share tile remains
+7. Verify behavior in a second browser window.
+   Expectation: remote participant sees the same structure.
+
+## Scope Check
+
+This is a safe next feature step because it stays concentrated in:
+
+- `src/services/livekit.ts`
+- `src/context/RoomVoiceContext.tsx`
+- `src/pages/RoomPage.tsx`
+
+It does not require new backend endpoints.

--- a/docs/superpowers/specs/2026-04-08-room-tile-focus-and-fullscreen-design.md
+++ b/docs/superpowers/specs/2026-04-08-room-tile-focus-and-fullscreen-design.md
@@ -1,0 +1,107 @@
+# Room Tile Focus And Fullscreen Design
+
+## Summary
+
+Add a unified room viewing mode for all video-based tiles in `RoomPage`.
+
+Any visual tile with a real video track should support:
+
+- `Expand`: switch the room into focused layout mode
+- `Fullscreen`: open that tile through the browser fullscreen API
+
+This applies to:
+
+- participant camera tiles
+- screen-share tiles
+
+Voice-only participant cards without video remain visible in the room, but do not support `Expand` or `Fullscreen`.
+
+## Goals
+
+- Let the user enlarge any camera or screen-share tile inside the room page
+- Keep room voice controls available while one tile is focused
+- Allow browser fullscreen for any visual tile with video
+- Preserve the current separate screen-share tile model
+
+## Non-Goals
+
+- No changes to LiveKit media transport
+- No changes to room membership, auth, or voice session lifecycle
+- No floating window or separate route for focused media
+
+## Tile Model
+
+`RoomPage` should build a unified list of visual tiles for layout and interaction.
+
+Each visual tile should have:
+
+- `id`
+- `kind: "camera" | "screen-share"`
+- `participant`
+- `track`
+- `title`
+
+Camera tiles and screen-share tiles are rendered from the same list, but can keep different visual styling.
+
+## Focus Mode
+
+`RoomPage` should keep one focused tile id:
+
+- `focusedTileId: string | null`
+
+When `focusedTileId` is `null`:
+
+- the page uses the normal grid layout
+
+When `focusedTileId` is set:
+
+- the selected tile is rendered in a large primary area
+- all remaining visual tiles are rendered in a horizontal strip near the bottom
+- room voice controls remain visible
+- voice-only participant cards remain outside the focus/fullscreen model and should not block the layout
+
+If the focused tile disappears because camera or screen share was turned off:
+
+- focus mode should fall back to another available visual tile if one exists
+- otherwise it should exit focus mode cleanly
+
+## Fullscreen
+
+Any visual tile with video should support `Fullscreen`.
+
+Implementation should use the browser fullscreen API on the tile container element.
+
+Rules:
+
+- fullscreen is available for both camera and screen-share tiles
+- fullscreen does not change room voice state
+- leaving fullscreen returns to the previous room layout state
+
+## UI Actions
+
+Normal grid mode:
+
+- visual tiles show `Expand` and `Fullscreen`
+- voice-only cards do not show these actions
+
+Focus mode:
+
+- focused tile shows `Exit focus` and `Fullscreen`
+- tiles in the bottom strip can be clicked to become the focused tile
+
+## Error Handling
+
+- if fullscreen is unavailable or rejected by the browser, keep the room layout unchanged
+- do not break voice controls or tile rendering on fullscreen failure
+
+## Testing
+
+Manual verification should cover:
+
+1. Expand a camera tile and verify focused layout
+2. Expand a screen-share tile and verify focused layout
+3. Switch focus from one tile to another via the bottom strip
+4. Fullscreen a camera tile
+5. Fullscreen a screen-share tile
+6. Turn off the currently focused camera or screen share and verify graceful fallback
+7. Exit focus mode and verify the normal grid layout returns

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,10 +91,10 @@ function App() {
   }
 
   return (
-    <AuthProvider>
-      <WebSocketProvider>
-        <AppWithCallProvider>
-          <Router>
+    <Router>
+      <AuthProvider>
+        <WebSocketProvider>
+          <AppWithCallProvider>
             <Routes>
               <Route path="/login" element={<LoginSignupPage />} />
               {/* Protected routes inside common Layout */}
@@ -108,10 +108,10 @@ function App() {
                 <Route path="/" element={<Navigate to="/home" />} />
               </Route>
             </Routes>
-          </Router>
-        </AppWithCallProvider>
-      </WebSocketProvider>
-    </AuthProvider>
+          </AppWithCallProvider>
+        </WebSocketProvider>
+      </AuthProvider>
+    </Router>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,12 +14,14 @@ import SettingsPage from "./pages/SettingsPage";
 import Loader from "./components/Loader";
 import { WebSocketProvider, useWebSocketContext } from "./context/WebSocketContext";
 import { CallProvider } from "./context/CallContext";
+import { RoomVoiceProvider } from "./context/RoomVoiceContext";
 import {
   IncomingCallModal,
   OutgoingCallModal,
   ActiveCallView,
 } from "./components/Call";
 import ChatPage from "./pages/ChatPage";
+import RoomVoiceDock from "./components/RoomVoiceDock";
 
 // Inner component that has access to WebSocket context
 const AppWithCallProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
@@ -27,11 +29,14 @@ const AppWithCallProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   return (
     <CallProvider wirechatClient={wirechatClient}>
-      {children}
-      {/* Global call modals - shown on any page */}
-      <IncomingCallModal />
-      <OutgoingCallModal />
-      <ActiveCallView />
+      <RoomVoiceProvider>
+        {children}
+        {/* Global call modals - shown on any page */}
+        <IncomingCallModal />
+        <OutgoingCallModal />
+        <ActiveCallView />
+        <RoomVoiceDock />
+      </RoomVoiceProvider>
     </CallProvider>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,34 +12,9 @@ import { AuthProvider } from "./context/AuthContext";
 import { isDesktop } from "./utils/platform";
 import SettingsPage from "./pages/SettingsPage";
 import Loader from "./components/Loader";
-import { WebSocketProvider, useWebSocketContext } from "./context/WebSocketContext";
-import { CallProvider } from "./context/CallContext";
 import { RoomVoiceProvider } from "./context/RoomVoiceContext";
-import {
-  IncomingCallModal,
-  OutgoingCallModal,
-  ActiveCallView,
-} from "./components/Call";
 import ChatPage from "./pages/ChatPage";
 import RoomVoiceDock from "./components/RoomVoiceDock";
-
-// Inner component that has access to WebSocket context
-const AppWithCallProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { wirechatClient } = useWebSocketContext();
-
-  return (
-    <CallProvider wirechatClient={wirechatClient}>
-      <RoomVoiceProvider>
-        {children}
-        {/* Global call modals - shown on any page */}
-        <IncomingCallModal />
-        <OutgoingCallModal />
-        <ActiveCallView />
-        <RoomVoiceDock />
-      </RoomVoiceProvider>
-    </CallProvider>
-  );
-};
 
 function App() {
   const [apiAvailable, setApiAvailable] = useState<boolean | null>(null);
@@ -93,8 +68,7 @@ function App() {
   return (
     <Router>
       <AuthProvider>
-        <WebSocketProvider>
-          <AppWithCallProvider>
+        <RoomVoiceProvider>
             <Routes>
               <Route path="/login" element={<LoginSignupPage />} />
               {/* Protected routes inside common Layout */}
@@ -108,8 +82,8 @@ function App() {
                 <Route path="/" element={<Navigate to="/home" />} />
               </Route>
             </Routes>
-          </AppWithCallProvider>
-        </WebSocketProvider>
+            <RoomVoiceDock />
+        </RoomVoiceProvider>
       </AuthProvider>
     </Router>
   );

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -27,19 +27,26 @@ const AppSidebar: React.FC = () => {
 
   useEffect(() => {
     if (!token) return;
-    const loadSidebarData = async () => {
+    const loadPinned = async () => {
       try {
-        const [pinnedList, conversationList] = await Promise.all([
-          fetchPinnedFriends(token),
-          fetchConversations(token),
-        ]);
+        const pinnedList = await fetchPinnedFriends(token);
         setPinned(pinnedList);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+
+    const loadConversations = async () => {
+      try {
+        const conversationList = await fetchConversations(token);
         setConversations(conversationList);
       } catch (err) {
         console.error(err);
       }
     };
-    loadSidebarData();
+
+    void loadPinned();
+    void loadConversations();
   }, [token]);
 
   const handlePinnedClick = (friend: Friend) => {

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from "react";
-import { Home, Users, Video, Settings } from "lucide-react";
+import { Home, Users, Video, Settings, MessageCircle } from "lucide-react";
 import { useAuth } from "../context/AuthContext";
 import { useNavigate, Link } from "react-router-dom";
-import { Friend } from "../types";
+import { ConversationInfo, Friend } from "../types";
+import { fetchConversations } from "../services/conversations-api";
 import { fetchPinnedFriends } from "../services/friends-api";
-import { MessageCircle } from "lucide-react";
 
 interface MenuItem {
   title: string;
@@ -23,23 +23,35 @@ const AppSidebar: React.FC = () => {
   const { user, token } = useAuth();
   const navigate = useNavigate();
   const [pinned, setPinned] = useState<Friend[]>([]);
+  const [conversations, setConversations] = useState<ConversationInfo[]>([]);
 
   useEffect(() => {
     if (!token) return;
-    const loadPinned = async () => {
+    const loadSidebarData = async () => {
       try {
-        const pinnedList = await fetchPinnedFriends(token);
+        const [pinnedList, conversationList] = await Promise.all([
+          fetchPinnedFriends(token),
+          fetchConversations(token),
+        ]);
         setPinned(pinnedList);
+        setConversations(conversationList);
       } catch (err) {
         console.error(err);
       }
     };
-    loadPinned();
+    loadSidebarData();
   }, [token]);
 
   const handlePinnedClick = (friend: Friend) => {
-    console.log("Friend from pinned", friend)
-    navigate(`/chat/${friend.user_id}`);
+    navigate(`/chat/${friend.user_id}`, {
+      state: { friendUsername: friend.username },
+    });
+  };
+
+  const handleConversationClick = (conversation: ConversationInfo) => {
+    navigate(`/chat/${conversation.user_id}`, {
+      state: { friendUsername: conversation.username },
+    });
   };
 
   return (
@@ -83,6 +95,37 @@ const AppSidebar: React.FC = () => {
           </ul>
         </div>
       )}
+      <div className="mt-6">
+        <h3 className="font-semibold mb-2">Messages</h3>
+        {conversations.length === 0 ? (
+          <p className="text-sm text-gray-500">No active chats yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {conversations.map((conversation) => (
+              <li key={conversation.user_id}>
+                <button
+                  type="button"
+                  onClick={() => handleConversationClick(conversation)}
+                  className="w-full text-left px-2 py-2 rounded hover:bg-blue-100 transition-colors"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="font-medium truncate">{conversation.username}</span>
+                    <span className="text-xs text-gray-500 whitespace-nowrap">
+                      {new Date(conversation.last_message_at).toLocaleTimeString([], {
+                        hour: "2-digit",
+                        minute: "2-digit",
+                      })}
+                    </span>
+                  </div>
+                  <p className="text-sm text-gray-600 truncate">
+                    {conversation.last_message}
+                  </p>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
     </aside>
   );
 };

--- a/src/components/Call/ActiveCallView.tsx
+++ b/src/components/Call/ActiveCallView.tsx
@@ -389,7 +389,7 @@ const ActiveCallView: React.FC = () => {
               {participants.map((p) => (
                 <VideoTile
                   key={p.sid}
-                  track={p.videoTrack || null}
+                  track={p.cameraTrack || null}
                   audioTrack={p.audioTrack || null}
                   name={p.name}
                   isMuted={p.isMuted}

--- a/src/components/RoomVoiceDock.tsx
+++ b/src/components/RoomVoiceDock.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { Mic, MicOff, Monitor, MonitorOff, PhoneOff, Video, VideoOff } from "lucide-react";
+
+import { useRoomVoice } from "../context/RoomVoiceContext";
+
+const buttonClass =
+  "w-10 h-10 rounded-full flex items-center justify-center transition-colors bg-gray-800 hover:bg-gray-700";
+
+const RoomVoiceDock: React.FC = () => {
+  const navigate = useNavigate();
+  const {
+    state,
+    toggleRoomVoiceMic,
+    toggleRoomVoiceCamera,
+    toggleRoomVoiceScreenShare,
+    leaveRoomVoiceSession,
+  } = useRoomVoice();
+
+  if (state.status === "idle" || !state.roomId) {
+    return null;
+  }
+
+  return (
+    <div className="fixed right-6 bottom-6 z-40 w-[360px] rounded-2xl border border-gray-700 bg-gray-900/95 shadow-2xl backdrop-blur">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800">
+        <div>
+          <div className="text-xs uppercase tracking-[0.2em] text-emerald-300/80">
+            Room Voice
+          </div>
+          <div className="text-sm font-semibold text-white">{state.roomName || state.roomId}</div>
+          <div className="text-xs text-white/60">
+            {state.status === "connecting"
+              ? "Connecting..."
+              : `${state.participants.length} connected`}
+          </div>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => navigate(`/room/${state.roomId}`, { state: { roomName: state.roomName } })}
+          className="px-3 py-1.5 rounded-lg bg-emerald-500 hover:bg-emerald-400 text-sm font-medium text-gray-950 transition-colors"
+        >
+          Open Room
+        </button>
+      </div>
+
+      <div className="flex items-center justify-between px-4 py-3">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void toggleRoomVoiceMic()}
+            disabled={state.status !== "active"}
+            className={buttonClass}
+            title={state.localMuted ? "Unmute" : "Mute"}
+          >
+            {state.localMuted ? (
+              <MicOff className="w-4 h-4 text-red-400" />
+            ) : (
+              <Mic className="w-4 h-4 text-white" />
+            )}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => void toggleRoomVoiceCamera()}
+            disabled={state.status !== "active"}
+            className={buttonClass}
+            title={state.localCameraOff ? "Turn on camera" : "Turn off camera"}
+          >
+            {state.localCameraOff ? (
+              <VideoOff className="w-4 h-4 text-red-400" />
+            ) : (
+              <Video className="w-4 h-4 text-white" />
+            )}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => void toggleRoomVoiceScreenShare()}
+            disabled={state.status !== "active"}
+            className={buttonClass}
+            title={state.screenSharing ? "Stop sharing" : "Share screen"}
+          >
+            {state.screenSharing ? (
+              <MonitorOff className="w-4 h-4 text-red-400" />
+            ) : (
+              <Monitor className="w-4 h-4 text-white" />
+            )}
+          </button>
+        </div>
+
+        <button
+          type="button"
+          onClick={() => void leaveRoomVoiceSession()}
+          className="w-11 h-11 rounded-full flex items-center justify-center bg-red-500 hover:bg-red-400 transition-colors"
+          title="Leave voice"
+        >
+          <PhoneOff className="w-5 h-5 text-white" />
+        </button>
+      </div>
+
+      {state.error && (
+        <div className="px-4 pb-3 text-xs text-red-300">{state.error}</div>
+      )}
+    </div>
+  );
+};
+
+export default RoomVoiceDock;

--- a/src/components/RoomVoiceDock.tsx
+++ b/src/components/RoomVoiceDock.tsx
@@ -55,9 +55,9 @@ const RoomVoiceDock: React.FC = () => {
             title={state.localMuted ? "Unmute" : "Mute"}
           >
             {state.localMuted ? (
-              <MicOff className="w-4 h-4 text-red-400" />
-            ) : (
               <Mic className="w-4 h-4 text-white" />
+            ) : (
+              <MicOff className="w-4 h-4 text-red-400" />
             )}
           </button>
 
@@ -69,9 +69,9 @@ const RoomVoiceDock: React.FC = () => {
             title={state.localCameraOff ? "Turn on camera" : "Turn off camera"}
           >
             {state.localCameraOff ? (
-              <VideoOff className="w-4 h-4 text-red-400" />
-            ) : (
               <Video className="w-4 h-4 text-white" />
+            ) : (
+              <VideoOff className="w-4 h-4 text-red-400" />
             )}
           </button>
 

--- a/src/components/RoomVoiceDock.tsx
+++ b/src/components/RoomVoiceDock.tsx
@@ -21,6 +21,8 @@ const RoomVoiceDock: React.FC = () => {
     return null;
   }
 
+  const encodedRoomId = encodeURIComponent(state.roomId);
+
   return (
     <div className="fixed right-6 bottom-6 z-40 w-[360px] rounded-2xl border border-gray-700 bg-gray-900/95 shadow-2xl backdrop-blur">
       <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800">
@@ -38,7 +40,11 @@ const RoomVoiceDock: React.FC = () => {
 
         <button
           type="button"
-          onClick={() => navigate(`/room/${state.roomId}`, { state: { roomName: state.roomName } })}
+          onClick={() =>
+            navigate(`/room/${encodedRoomId}`, {
+              state: { roomName: state.roomName },
+            })
+          }
           className="px-3 py-1.5 rounded-lg bg-emerald-500 hover:bg-emerald-400 text-sm font-medium text-gray-950 transition-colors"
         >
           Open Room

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -31,8 +31,10 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const me = await getMe(storedToken);
       setUser(me);
     } catch (error) {
-      // Fall back to JWT payload when profile fetch fails.
-      setUser(userInfo);
+      console.error("Failed to hydrate current user:", error);
+      await removeToken();
+      setTokenState(null);
+      setUser(null);
     }
   };
 

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -12,6 +12,7 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
+// AuthProvider keeps authenticated user state in sync with token storage and the backend profile.
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [token, setTokenState] = useState<string | null>(null);
   const [user, setUser] = useState<User | null>(null);

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { getToken, saveToken, removeToken } from "../adapters/token-adapter";
-import { decodeJWT } from "../services/api";
+import { decodeJWT, getMe } from "../services/api";
 import { User } from "../types";
 
 interface AuthContextType {
@@ -17,21 +17,32 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
 
+  const hydrateUser = async (storedToken: string) => {
+    const userInfo = decodeJWT(storedToken);
+    if (!userInfo) {
+      console.error("Failed to decode token");
+      await removeToken();
+      setTokenState(null);
+      setUser(null);
+      return;
+    }
+
+    try {
+      const me = await getMe(storedToken);
+      setUser(me);
+    } catch (error) {
+      // Fall back to JWT payload when profile fetch fails.
+      setUser(userInfo);
+    }
+  };
+
   useEffect(() => {
     const loadTokenAndUser = async () => {
       const storedToken = await getToken();
       setTokenState(storedToken);
 
       if (storedToken) {
-        const userInfo = decodeJWT(storedToken);
-        if (userInfo) {
-          setUser(userInfo);
-        } else {
-          console.error("Failed to decode token");
-          removeToken();
-          setTokenState(null);
-          setUser(null);
-        }
+        await hydrateUser(storedToken);
       }
 
       setLoading(false);
@@ -44,15 +55,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     setTokenState(newToken);
     if (newToken) {
       await saveToken(newToken);
-      const userInfo = decodeJWT(newToken);
-      if (userInfo) {
-        setUser(userInfo);
-      } else {
-        console.error("Failed to decode token");
-        removeToken();
-        setTokenState(null);
-        setUser(null);
-      }
+      await hydrateUser(newToken);
     } else {
       await removeToken();
       setUser(null);

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
 import { getToken, saveToken, removeToken } from "../adapters/token-adapter";
-import { decodeJWT, getMe } from "../services/api";
+import { getMe } from "../services/api";
 import { User } from "../types";
 
 interface AuthContextType {
@@ -18,15 +18,6 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
   const [loading, setLoading] = useState(true);
 
   const hydrateUser = async (storedToken: string) => {
-    const userInfo = decodeJWT(storedToken);
-    if (!userInfo) {
-      console.error("Failed to decode token");
-      await removeToken();
-      setTokenState(null);
-      setUser(null);
-      return;
-    }
-
     try {
       const me = await getMe(storedToken);
       setUser(me);

--- a/src/context/RoomVoiceContext.tsx
+++ b/src/context/RoomVoiceContext.tsx
@@ -65,9 +65,13 @@ const RoomVoiceContext = createContext<RoomVoiceContextValue | undefined>(undefi
 export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const { token } = useAuth();
+  const { token, logout } = useAuth();
   const clientRef = useRef<LiveKitClient | null>(null);
   const [state, setState] = useState<RoomVoiceState>(initialState);
+
+  const isSessionError = useCallback((message: string) => {
+    return message.startsWith("Session expired:") || message === "Not authenticated";
+  }, []);
 
   const syncParticipants = useCallback(() => {
     const participants = clientRef.current?.getAllParticipants() ?? [];
@@ -92,6 +96,19 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
     });
   }, []);
 
+  const handleSessionFailure = useCallback(
+    async (message: string) => {
+      try {
+        await clientRef.current?.disconnect();
+      } catch {
+        // Best-effort disconnect for stale sessions.
+      }
+      resetState(message);
+      logout();
+    },
+    [logout, resetState]
+  );
+
   const leaveRoomVoiceSession = useCallback(async (roomIdOverride?: string) => {
     const roomId = roomIdOverride ?? state.roomId;
     const client = clientRef.current;
@@ -112,8 +129,13 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
       }
     }
 
+    if (leaveError && isSessionError(leaveError)) {
+      await handleSessionFailure(leaveError);
+      return;
+    }
+
     resetState(leaveError);
-  }, [resetState, state.roomId, token]);
+  }, [handleSessionFailure, isSessionError, resetState, state.roomId, token]);
 
   const joinRoomVoiceSession = useCallback(
     async (roomId: string, roomName?: string) => {
@@ -204,10 +226,15 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
         } catch {
           // Best-effort cleanup for partially created room voice presence.
         }
+
+        if (isSessionError(message)) {
+          await handleSessionFailure(message);
+          return;
+        }
         resetState(message);
       }
     },
-    [leaveRoomVoiceSession, resetState, state.roomId, syncParticipants, token]
+    [handleSessionFailure, isSessionError, leaveRoomVoiceSession, resetState, state.roomId, syncParticipants, token]
   );
 
   const syncMediaState = useCallback(
@@ -238,9 +265,13 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Failed to toggle microphone";
+      if (isSessionError(message)) {
+        await handleSessionFailure(message);
+        return;
+      }
       setState((current) => ({ ...current, error: message }));
     }
-  }, [state.status, syncMediaState, syncParticipants]);
+  }, [handleSessionFailure, isSessionError, state.status, syncMediaState, syncParticipants]);
 
   const toggleRoomVoiceCamera = useCallback(async () => {
     if (!clientRef.current || state.status !== "active") {
@@ -255,9 +286,13 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Failed to toggle camera";
+      if (isSessionError(message)) {
+        await handleSessionFailure(message);
+        return;
+      }
       setState((current) => ({ ...current, error: message }));
     }
-  }, [state.status, syncMediaState, syncParticipants]);
+  }, [handleSessionFailure, isSessionError, state.status, syncMediaState, syncParticipants]);
 
   const toggleRoomVoiceScreenShare = useCallback(async () => {
     if (!clientRef.current || state.status !== "active") {
@@ -272,9 +307,13 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Failed to toggle screen share";
+      if (isSessionError(message)) {
+        await handleSessionFailure(message);
+        return;
+      }
       setState((current) => ({ ...current, error: message }));
     }
-  }, [state.status, syncMediaState, syncParticipants]);
+  }, [handleSessionFailure, isSessionError, state.status, syncMediaState, syncParticipants]);
 
   const clearRoomVoiceError = useCallback(() => {
     setState((current) => ({ ...current, error: null }));

--- a/src/context/RoomVoiceContext.tsx
+++ b/src/context/RoomVoiceContext.tsx
@@ -14,6 +14,7 @@ import {
   LiveKitClient,
   ParticipantInfo,
 } from "../services/livekit";
+import { Track } from "livekit-client";
 import {
   fetchRoomVoiceCredentials,
   joinRoomVoice,
@@ -55,7 +56,7 @@ interface RoomVoiceContextValue {
   toggleRoomVoiceCamera: () => Promise<void>;
   toggleRoomVoiceScreenShare: () => Promise<void>;
   clearRoomVoiceError: () => void;
-  getLocalVideoTrack: () => MediaStreamTrack | null;
+  getLocalVideoTrack: () => Track | null;
   getParticipants: () => ParticipantInfo[];
   livekitClient: LiveKitClient | null;
 }
@@ -188,6 +189,8 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
           },
           onParticipantConnected: syncParticipants,
           onParticipantDisconnected: syncParticipants,
+          onLocalTrackPublished: syncParticipants,
+          onLocalTrackUnpublished: syncParticipants,
           onTrackSubscribed: syncParticipants,
           onTrackUnsubscribed: syncParticipants,
           onTrackMuted: syncParticipants,
@@ -320,8 +323,7 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
   }, []);
 
   const getLocalVideoTrack = useCallback(() => {
-    const track = clientRef.current?.getLocalVideoTrack();
-    return track?.mediaStreamTrack ?? null;
+    return clientRef.current?.getLocalVideoTrack() ?? null;
   }, []);
 
   const getParticipants = useCallback(() => {

--- a/src/context/RoomVoiceContext.tsx
+++ b/src/context/RoomVoiceContext.tsx
@@ -57,6 +57,7 @@ interface RoomVoiceContextValue {
   toggleRoomVoiceScreenShare: () => Promise<void>;
   clearRoomVoiceError: () => void;
   getLocalVideoTrack: () => Track | null;
+  getLocalScreenShareTrack: () => Track | null;
   getParticipants: () => ParticipantInfo[];
   livekitClient: LiveKitClient | null;
 }
@@ -326,6 +327,10 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
     return clientRef.current?.getLocalVideoTrack() ?? null;
   }, []);
 
+  const getLocalScreenShareTrack = useCallback(() => {
+    return clientRef.current?.getScreenShareTrack() ?? null;
+  }, []);
+
   const getParticipants = useCallback(() => {
     return clientRef.current?.getAllParticipants() ?? [];
   }, []);
@@ -340,12 +345,14 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
       toggleRoomVoiceScreenShare,
       clearRoomVoiceError,
       getLocalVideoTrack,
+      getLocalScreenShareTrack,
       getParticipants,
       livekitClient: clientRef.current,
     }),
     [
       clearRoomVoiceError,
       getLocalVideoTrack,
+      getLocalScreenShareTrack,
       getParticipants,
       joinRoomVoiceSession,
       leaveRoomVoiceSession,

--- a/src/context/RoomVoiceContext.tsx
+++ b/src/context/RoomVoiceContext.tsx
@@ -1,0 +1,329 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+import { useAuth } from "./AuthContext";
+import {
+  createLiveKitClient,
+  LiveKitClient,
+  ParticipantInfo,
+} from "../services/livekit";
+import {
+  fetchRoomVoiceCredentials,
+  joinRoomVoice,
+  leaveRoomVoice,
+  updateRoomVoiceMedia,
+} from "../services/rooms-api";
+
+export type RoomVoiceStatus = "idle" | "connecting" | "active";
+
+export interface RoomVoiceState {
+  status: RoomVoiceStatus;
+  roomId: string | null;
+  roomName: string | null;
+  participants: ParticipantInfo[];
+  localMuted: boolean;
+  localCameraOff: boolean;
+  screenSharing: boolean;
+  error: string | null;
+  connectedAt: number | null;
+}
+
+const initialState: RoomVoiceState = {
+  status: "idle",
+  roomId: null,
+  roomName: null,
+  participants: [],
+  localMuted: true,
+  localCameraOff: true,
+  screenSharing: false,
+  error: null,
+  connectedAt: null,
+};
+
+interface RoomVoiceContextValue {
+  state: RoomVoiceState;
+  joinRoomVoiceSession: (roomId: string, roomName?: string) => Promise<void>;
+  leaveRoomVoiceSession: (roomIdOverride?: string) => Promise<void>;
+  toggleRoomVoiceMic: () => Promise<void>;
+  toggleRoomVoiceCamera: () => Promise<void>;
+  toggleRoomVoiceScreenShare: () => Promise<void>;
+  clearRoomVoiceError: () => void;
+  getLocalVideoTrack: () => MediaStreamTrack | null;
+  getParticipants: () => ParticipantInfo[];
+  livekitClient: LiveKitClient | null;
+}
+
+const RoomVoiceContext = createContext<RoomVoiceContextValue | undefined>(undefined);
+
+export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { token } = useAuth();
+  const clientRef = useRef<LiveKitClient | null>(null);
+  const [state, setState] = useState<RoomVoiceState>(initialState);
+
+  const syncParticipants = useCallback(() => {
+    const participants = clientRef.current?.getAllParticipants() ?? [];
+    setState((current) => ({ ...current, participants }));
+  }, []);
+
+  useEffect(() => {
+    if (!clientRef.current) {
+      clientRef.current = createLiveKitClient();
+    }
+
+    return () => {
+      void clientRef.current?.disconnect();
+      clientRef.current?.clearHandlers();
+    };
+  }, []);
+
+  const resetState = useCallback((error: string | null = null) => {
+    setState({
+      ...initialState,
+      error,
+    });
+  }, []);
+
+  const leaveRoomVoiceSession = useCallback(async (roomIdOverride?: string) => {
+    const roomId = roomIdOverride ?? state.roomId;
+    const client = clientRef.current;
+
+    try {
+      await client?.disconnect();
+    } catch (error) {
+      console.warn("[RoomVoiceContext] Failed to disconnect LiveKit room voice:", error);
+    }
+
+    let leaveError: string | null = null;
+    if (roomId && token) {
+      try {
+        await leaveRoomVoice(roomId, token);
+      } catch (error) {
+        leaveError =
+          error instanceof Error ? error.message : "Failed to leave room voice";
+      }
+    }
+
+    resetState(leaveError);
+  }, [resetState, state.roomId, token]);
+
+  const joinRoomVoiceSession = useCallback(
+    async (roomId: string, roomName?: string) => {
+      if (!token) {
+        resetState("Not authenticated");
+        return;
+      }
+
+      if (state.roomId === roomId && state.status === "active") {
+        return;
+      }
+
+      if (!clientRef.current) {
+        clientRef.current = createLiveKitClient();
+      }
+
+      if (state.roomId && state.roomId !== roomId) {
+        await leaveRoomVoiceSession();
+      }
+
+      setState((current) => ({
+        ...current,
+        status: "connecting",
+        roomId,
+        roomName: roomName ?? current.roomName,
+        error: null,
+      }));
+
+      try {
+        await joinRoomVoice(roomId, token);
+        const credentials = await fetchRoomVoiceCredentials(roomId, token);
+
+        clientRef.current.setHandlers({
+          onConnected: () => {
+            syncParticipants();
+            setState((current) => ({
+              ...current,
+              status: "active",
+              roomId,
+              roomName: roomName ?? current.roomName ?? credentials.room_name,
+              localMuted: !clientRef.current?.isMicEnabled(),
+              localCameraOff: !clientRef.current?.isCameraEnabled(),
+              screenSharing: clientRef.current?.isScreenShareEnabled() ?? false,
+              connectedAt: Date.now(),
+              error: null,
+            }));
+          },
+          onDisconnected: () => {
+            resetState(null);
+          },
+          onParticipantConnected: syncParticipants,
+          onParticipantDisconnected: syncParticipants,
+          onTrackSubscribed: syncParticipants,
+          onTrackUnsubscribed: syncParticipants,
+          onTrackMuted: syncParticipants,
+          onTrackUnmuted: syncParticipants,
+          onMicMuted: (muted) => {
+            setState((current) => ({ ...current, localMuted: muted }));
+            syncParticipants();
+          },
+          onCameraMuted: (muted) => {
+            setState((current) => ({ ...current, localCameraOff: muted }));
+            syncParticipants();
+          },
+          onScreenShareStarted: () => {
+            setState((current) => ({ ...current, screenSharing: true }));
+            syncParticipants();
+          },
+          onScreenShareStopped: () => {
+            setState((current) => ({ ...current, screenSharing: false }));
+            syncParticipants();
+          },
+          onError: (error) => {
+            setState((current) => ({ ...current, error: error.message }));
+          },
+        });
+
+        await clientRef.current.connect({
+          url: credentials.url,
+          token: credentials.token,
+          roomName: credentials.room_name,
+        });
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Failed to join room voice";
+        try {
+          await leaveRoomVoice(roomId, token);
+        } catch {
+          // Best-effort cleanup for partially created room voice presence.
+        }
+        resetState(message);
+      }
+    },
+    [leaveRoomVoiceSession, resetState, state.roomId, syncParticipants, token]
+  );
+
+  const syncMediaState = useCallback(
+    async (patch: {
+      is_mic_enabled?: boolean;
+      is_camera_enabled?: boolean;
+      is_screen_sharing?: boolean;
+    }) => {
+      if (!token || !state.roomId) {
+        return;
+      }
+
+      await updateRoomVoiceMedia(state.roomId, patch, token);
+    },
+    [state.roomId, token]
+  );
+
+  const toggleRoomVoiceMic = useCallback(async () => {
+    if (!clientRef.current || state.status !== "active") {
+      return;
+    }
+
+    try {
+      const enabled = await clientRef.current.toggleMic();
+      setState((current) => ({ ...current, localMuted: !enabled, error: null }));
+      await syncMediaState({ is_mic_enabled: enabled });
+      syncParticipants();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to toggle microphone";
+      setState((current) => ({ ...current, error: message }));
+    }
+  }, [state.status, syncMediaState, syncParticipants]);
+
+  const toggleRoomVoiceCamera = useCallback(async () => {
+    if (!clientRef.current || state.status !== "active") {
+      return;
+    }
+
+    try {
+      const enabled = await clientRef.current.toggleCamera();
+      setState((current) => ({ ...current, localCameraOff: !enabled, error: null }));
+      await syncMediaState({ is_camera_enabled: enabled });
+      syncParticipants();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to toggle camera";
+      setState((current) => ({ ...current, error: message }));
+    }
+  }, [state.status, syncMediaState, syncParticipants]);
+
+  const toggleRoomVoiceScreenShare = useCallback(async () => {
+    if (!clientRef.current || state.status !== "active") {
+      return;
+    }
+
+    try {
+      const enabled = await clientRef.current.toggleScreenShare();
+      setState((current) => ({ ...current, screenSharing: enabled, error: null }));
+      await syncMediaState({ is_screen_sharing: enabled });
+      syncParticipants();
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to toggle screen share";
+      setState((current) => ({ ...current, error: message }));
+    }
+  }, [state.status, syncMediaState, syncParticipants]);
+
+  const clearRoomVoiceError = useCallback(() => {
+    setState((current) => ({ ...current, error: null }));
+  }, []);
+
+  const getLocalVideoTrack = useCallback(() => {
+    const track = clientRef.current?.getLocalVideoTrack();
+    return track?.mediaStreamTrack ?? null;
+  }, []);
+
+  const getParticipants = useCallback(() => {
+    return clientRef.current?.getAllParticipants() ?? [];
+  }, []);
+
+  const value = useMemo<RoomVoiceContextValue>(
+    () => ({
+      state,
+      joinRoomVoiceSession,
+      leaveRoomVoiceSession,
+      toggleRoomVoiceMic,
+      toggleRoomVoiceCamera,
+      toggleRoomVoiceScreenShare,
+      clearRoomVoiceError,
+      getLocalVideoTrack,
+      getParticipants,
+      livekitClient: clientRef.current,
+    }),
+    [
+      clearRoomVoiceError,
+      getLocalVideoTrack,
+      getParticipants,
+      joinRoomVoiceSession,
+      leaveRoomVoiceSession,
+      state,
+      toggleRoomVoiceCamera,
+      toggleRoomVoiceMic,
+      toggleRoomVoiceScreenShare,
+    ]
+  );
+
+  return (
+    <RoomVoiceContext.Provider value={value}>{children}</RoomVoiceContext.Provider>
+  );
+};
+
+export const useRoomVoice = () => {
+  const context = useContext(RoomVoiceContext);
+  if (!context) {
+    throw new Error("useRoomVoice must be used within a RoomVoiceProvider");
+  }
+  return context;
+};

--- a/src/context/RoomVoiceContext.tsx
+++ b/src/context/RoomVoiceContext.tsx
@@ -22,8 +22,10 @@ import {
   updateRoomVoiceMedia,
 } from "../services/rooms-api";
 
+// RoomVoiceStatus represents the lifecycle of the room-scoped voice session.
 export type RoomVoiceStatus = "idle" | "connecting" | "active";
 
+// RoomVoiceState stores the current room voice session, participants, and local media flags.
 export interface RoomVoiceState {
   status: RoomVoiceStatus;
   roomId: string | null;
@@ -64,6 +66,7 @@ interface RoomVoiceContextValue {
 
 const RoomVoiceContext = createContext<RoomVoiceContextValue | undefined>(undefined);
 
+// RoomVoiceProvider manages the persistent room-scoped voice session and LiveKit client.
 export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {

--- a/src/context/RoomVoiceContext.tsx
+++ b/src/context/RoomVoiceContext.tsx
@@ -72,6 +72,7 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const { token, logout } = useAuth();
   const clientRef = useRef<LiveKitClient | null>(null);
+  const transitionInProgressRef = useRef(false);
   const [state, setState] = useState<RoomVoiceState>(initialState);
 
   const isSessionError = useCallback((message: string) => {
@@ -144,6 +145,10 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const joinRoomVoiceSession = useCallback(
     async (roomId: string, roomName?: string) => {
+      if (transitionInProgressRef.current) {
+        return;
+      }
+
       if (!token) {
         resetState("Not authenticated");
         return;
@@ -157,19 +162,21 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
         clientRef.current = createLiveKitClient();
       }
 
-      if (state.roomId && state.roomId !== roomId) {
-        await leaveRoomVoiceSession();
-      }
-
-      setState((current) => ({
-        ...current,
-        status: "connecting",
-        roomId,
-        roomName: roomName ?? current.roomName,
-        error: null,
-      }));
+      transitionInProgressRef.current = true;
 
       try {
+        if (state.roomId && state.roomId !== roomId) {
+          await leaveRoomVoiceSession();
+        }
+
+        setState((current) => ({
+          ...current,
+          status: "connecting",
+          roomId,
+          roomName: roomName ?? current.roomName,
+          error: null,
+        }));
+
         await joinRoomVoice(roomId, token);
         const credentials = await fetchRoomVoiceCredentials(roomId, token);
 
@@ -239,6 +246,8 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
           return;
         }
         resetState(message);
+      } finally {
+        transitionInProgressRef.current = false;
       }
     },
     [handleSessionFailure, isSessionError, leaveRoomVoiceSession, resetState, state.roomId, syncParticipants, token]

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -34,6 +34,7 @@ const ChatPage: React.FC = () => {
 
   const socketRef = useRef<WebSocket | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const loadRequestIdRef = useRef(0);
   const routeState = location.state as { friendUsername?: string } | null;
 
   const friendUserID = friendId ? decodeURIComponent(friendId) : "";
@@ -49,6 +50,8 @@ const ChatPage: React.FC = () => {
         return;
       }
 
+      const requestId = loadRequestIdRef.current + 1;
+      loadRequestIdRef.current = requestId;
       setIsLoading(true);
       setError(null);
 
@@ -64,12 +67,21 @@ const ChatPage: React.FC = () => {
             : getUserInfo(token, friendUserID),
         ]);
 
+        if (loadRequestIdRef.current !== requestId) {
+          return;
+        }
+
         setMessages(history);
         setFriendUsername(friendInfo.username || `user-${friendUserID}`);
       } catch (err) {
+        if (loadRequestIdRef.current !== requestId) {
+          return;
+        }
         setError(err instanceof Error ? err.message : "Failed to load chat");
       } finally {
-        setIsLoading(false);
+        if (loadRequestIdRef.current === requestId) {
+          setIsLoading(false);
+        }
       }
     };
 

--- a/src/pages/ChatPage.tsx
+++ b/src/pages/ChatPage.tsx
@@ -1,133 +1,180 @@
-/**
- * Chat Page
- * Direct message chat using WireChat WebSocket protocol with direct rooms
- */
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { ArrowLeft, Loader2, Send, Video } from "lucide-react";
 
-import React, { useEffect, useState, useRef } from "react";
-import { useParams, useNavigate, useLocation } from "react-router-dom";
-import { ArrowLeft, Send, Video, Loader2 } from "lucide-react";
-import { useAuth } from "../context/AuthContext";
-import { useWebSocketContext } from "../context/WebSocketContext";
-import { useCall } from "../context/CallContext";
-import { getOrCreateDirectRoom } from "../services/rooms-api";
 import Button from "../components/Button";
+import { useAuth } from "../context/AuthContext";
+import { getUserInfo } from "../services/api";
+import {
+  connectDirectChatSocket,
+  fetchDirectChatHistory,
+} from "../services/chat-api";
+import { getOrCreateDirectRoom } from "../services/rooms-api";
+
+interface ChatMessageView {
+  id: number | string;
+  sender_id: string;
+  receiver_id: string;
+  text: string;
+  created_at: string;
+}
 
 const ChatPage: React.FC = () => {
   const { friendId } = useParams();
   const navigate = useNavigate();
   const location = useLocation();
   const { user, token } = useAuth();
-  const {
-    joinRoom,
-    leaveRoom,
-    sendMessage,
-    getMessagesForRoom,
-    isConnected,
-  } = useWebSocketContext();
-  const { initiateCall, state: callState } = useCall();
 
-  const [inputMessage, setInputMessage] = useState("");
   const [friendUsername, setFriendUsername] = useState("");
-  const [friendUserId, setFriendUserId] = useState<number | null>(null);
-  const [roomName, setRoomName] = useState<string | null>(null);
+  const [messages, setMessages] = useState<ChatMessageView[]>([]);
+  const [inputMessage, setInputMessage] = useState("");
   const [isLoading, setIsLoading] = useState(true);
+  const [isSocketOpen, setIsSocketOpen] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const socketRef = useRef<WebSocket | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+  const routeState = location.state as { friendUsername?: string } | null;
 
-  // Scroll to bottom when messages change
-  const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  };
+  const friendUserID = friendId ? decodeURIComponent(friendId) : "";
 
-  const state = location.state as { friendUsername?: string } | null;
-
-  // Get or create direct room
   useEffect(() => {
-    const initChat = async () => {
-      if (!token || !friendId) return;
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
+  useEffect(() => {
+    const loadChat = async () => {
+      if (!token || !friendUserID) {
+        setIsLoading(false);
+        return;
+      }
 
       setIsLoading(true);
       setError(null);
 
       try {
-        const targetUserID = Number(friendId);
-        if (!Number.isFinite(targetUserID) || targetUserID <= 0) {
-          throw new Error("Invalid friend ID");
-        }
+        const [history, friendInfo] = await Promise.all([
+          fetchDirectChatHistory(token, friendUserID),
+          routeState?.friendUsername
+            ? Promise.resolve({
+                id: 0,
+                username: routeState.friendUsername,
+                name: routeState.friendUsername,
+              })
+            : getUserInfo(token, friendUserID),
+        ]);
 
-        setFriendUserId(targetUserID);
-        setFriendUsername(state?.friendUsername || `user-${targetUserID}`);
-
-        // Get or create direct room
-        const directRoom = await getOrCreateDirectRoom(targetUserID, token);
-        const roomIdentifier = directRoom.name || `direct-${directRoom.id}`;
-        setRoomName(roomIdentifier);
-
-        // Join the room
-        if (isConnected) {
-          joinRoom(roomIdentifier);
-        }
+        setMessages(history);
+        setFriendUsername(friendInfo.username || `user-${friendUserID}`);
       } catch (err) {
-        console.error("Failed to initialize chat:", err);
-        setError(err instanceof Error ? err.message : "Failed to initialize chat");
+        setError(err instanceof Error ? err.message : "Failed to load chat");
       } finally {
         setIsLoading(false);
       }
     };
 
-    initChat();
-
-  }, [token, friendId, state?.friendUsername, isConnected, joinRoom]);
+    void loadChat();
+  }, [friendUserID, routeState?.friendUsername, token]);
 
   useEffect(() => {
-    return () => {
-      if (roomName) {
-        leaveRoom(roomName);
-      }
-    };
-  }, [roomName, leaveRoom]);
-
-  // Join room when connection is established
-  useEffect(() => {
-    if (roomName && isConnected) {
-      joinRoom(roomName);
+    if (!token || !user?.user_id || !friendUserID) {
+      return undefined;
     }
-  }, [roomName, isConnected, joinRoom]);
 
-  // Get messages for this room
-  const messages = roomName ? getMessagesForRoom(roomName) : [];
+    const socket = connectDirectChatSocket(token, {
+      onOpen: () => setIsSocketOpen(true),
+      onClose: () => setIsSocketOpen(false),
+      onError: () => {
+        setIsSocketOpen(false);
+        setError((current) => current ?? "Chat connection error");
+      },
+      onMessage: (message) => {
+        const isRelevant =
+          (message.from === friendUserID && message.to === user.user_id) ||
+          (message.from === user.user_id && message.to === friendUserID);
 
-  // Scroll to bottom when messages update
-  useEffect(() => {
-    scrollToBottom();
-  }, [messages]);
+        if (!isRelevant) {
+          return;
+        }
+
+        setMessages((current) => [
+          ...current,
+          {
+            id: `${message.from}-${Date.now()}`,
+            sender_id: message.from,
+            receiver_id: message.to,
+            text: message.message,
+            created_at: new Date().toISOString(),
+          },
+        ]);
+      },
+    });
+
+    socketRef.current = socket;
+
+    return () => {
+      socket.close(1000, "chat page closed");
+      socketRef.current = null;
+    };
+  }, [friendUserID, token, user?.user_id]);
+
+  const sortedMessages = useMemo(
+    () =>
+      [...messages].sort(
+        (left, right) =>
+          new Date(left.created_at).getTime() - new Date(right.created_at).getTime()
+      ),
+    [messages]
+  );
 
   const handleSend = () => {
-    if (!roomName || !inputMessage.trim()) return;
-    sendMessage(roomName, inputMessage.trim());
+    const text = inputMessage.trim();
+    if (!text || !socketRef.current || socketRef.current.readyState !== WebSocket.OPEN || !user) {
+      return;
+    }
+
+    socketRef.current.send(
+      JSON.stringify({
+        to: friendUserID,
+        message: text,
+      })
+    );
+
+    setMessages((current) => [
+      ...current,
+      {
+        id: `local-${Date.now()}`,
+        sender_id: user.user_id,
+        receiver_id: friendUserID,
+        text,
+        created_at: new Date().toISOString(),
+      },
+    ]);
     setInputMessage("");
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
       handleSend();
     }
   };
 
-  const handleVideoCall = () => {
-    if (friendUserId) {
-      initiateCall("direct", friendUserId, friendUsername);
+  const handleOpenVoiceRoom = async () => {
+    if (!token) return;
+
+    try {
+      const room = await getOrCreateDirectRoom(friendUserID, token);
+      navigate(`/room/${encodeURIComponent(room.room_id)}`, {
+        state: { roomName: `Private voice with ${friendUsername || "friend"}` },
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to open private voice room");
     }
   };
 
-  const canMakeCall = callState.status === "idle" || callState.status === "ended";
-
-  // Format timestamp
-  const formatTime = (ts: number) => {
-    const date = new Date(ts * 1000);
-    return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-  };
+  const formatTime = (value: string) =>
+    new Date(value).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 
   if (isLoading) {
     return (
@@ -138,7 +185,7 @@ const ChatPage: React.FC = () => {
     );
   }
 
-  if (error) {
+  if (error && sortedMessages.length === 0) {
     return (
       <div className="flex flex-col h-screen items-center justify-center bg-gray-50 p-4">
         <div className="text-center max-w-md">
@@ -154,7 +201,6 @@ const ChatPage: React.FC = () => {
 
   return (
     <div className="flex flex-col h-screen bg-gray-50">
-      {/* Header */}
       <header className="flex items-center justify-between px-4 py-3 bg-white border-b shadow-sm">
         <div className="flex items-center gap-3">
           <button
@@ -164,37 +210,33 @@ const ChatPage: React.FC = () => {
             <ArrowLeft className="w-5 h-5 text-gray-600" />
           </button>
           <div>
-            <h1 className="font-semibold text-gray-900">{friendUsername}</h1>
+            <h1 className="font-semibold text-gray-900">{friendUsername || "Direct chat"}</h1>
             <p className="text-xs text-gray-500">
-              {isConnected ? "Online" : "Connecting..."}
+              {isSocketOpen ? "Connected" : "Connecting..."}
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-2">
-          <button
-            onClick={handleVideoCall}
-            disabled={!canMakeCall}
-            className="p-2 rounded-lg hover:bg-gray-100 transition-colors disabled:opacity-50"
-            title="Video call"
-          >
-            <Video className="w-5 h-5 text-primary" />
-          </button>
-        </div>
+        <button
+          onClick={() => void handleOpenVoiceRoom()}
+          className="p-2 rounded-lg hover:bg-gray-100 transition-colors"
+          title="Open private voice room"
+        >
+          <Video className="w-5 h-5 text-primary" />
+        </button>
       </header>
 
-      {/* Messages */}
       <main className="flex-1 overflow-y-auto p-4 space-y-4">
-        {messages.length === 0 ? (
+        {sortedMessages.length === 0 ? (
           <div className="flex flex-col items-center justify-center h-full text-gray-500">
             <p>No messages yet</p>
-            <p className="text-sm">Start the conversation!</p>
+            <p className="text-sm">Start the conversation.</p>
           </div>
         ) : (
-          messages.map((msg, idx) => {
-            const isMe = msg.isLocal || msg.user === user?.username;
+          sortedMessages.map((msg) => {
+            const isMe = msg.sender_id === user?.user_id;
             return (
               <div
-                key={msg.id || idx}
+                key={msg.id}
                 className={`flex ${isMe ? "justify-end" : "justify-start"}`}
               >
                 <div
@@ -210,7 +252,7 @@ const ChatPage: React.FC = () => {
                       isMe ? "text-white/70" : "text-gray-400"
                     }`}
                   >
-                    {formatTime(msg.timestamp)}
+                    {formatTime(msg.created_at)}
                   </p>
                 </div>
               </div>
@@ -220,20 +262,20 @@ const ChatPage: React.FC = () => {
         <div ref={messagesEndRef} />
       </main>
 
-      {/* Input */}
       <div className="p-4 bg-white border-t">
+        {error && <p className="mb-2 text-sm text-red-500">{error}</p>}
         <div className="flex items-center gap-2">
           <input
             type="text"
             value={inputMessage}
-            onChange={(e) => setInputMessage(e.target.value)}
-            onKeyDown={handleKeyPress}
+            onChange={(event) => setInputMessage(event.target.value)}
+            onKeyDown={handleKeyDown}
             placeholder="Type a message..."
             className="flex-1 px-4 py-2 rounded-full border border-gray-300 focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary"
           />
           <button
             onClick={handleSend}
-            disabled={!inputMessage.trim()}
+            disabled={!inputMessage.trim() || !isSocketOpen}
             className="p-3 bg-primary text-white rounded-full hover:bg-primary-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <Send className="w-5 h-5" />

--- a/src/pages/FriendsPage.tsx
+++ b/src/pages/FriendsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { MessageCircle, Video } from "lucide-react";
+import { MessageCircle, Trash2, Video } from "lucide-react";
 
 import { useAuth } from "../context/AuthContext";
 import Button from "../components/Button";
@@ -11,6 +11,7 @@ import {
   requestFriend,
   fetchFriends,
   searchUsers,
+  removeFriend,
 } from "../services/friends-api";
 import { getOrCreateDirectRoom } from "../services/rooms-api";
 import { FriendRequest, Friend, UserInfo } from "../types";
@@ -189,6 +190,19 @@ const FriendsPage: React.FC = () => {
     }
   };
 
+  const handleRemoveFriend = async (friend: Friend) => {
+    if (!token) return;
+
+    try {
+      await removeFriend(friend.username, token);
+      setFriends((current) => current.filter((item) => item.user_id !== friend.user_id));
+      setSuccess(`${friend.username} удалён из друзей`);
+      setTimeout(() => setSuccess(""), 3000);
+    } catch (err: any) {
+      setError(err.message || "Failed to remove friend");
+    }
+  };
+
   const goToChat = (friend: Friend) => {
     navigate(`/chat/${friend.friend_user_id}`, {
       state: { friendUsername: friend.username },
@@ -296,6 +310,14 @@ const FriendsPage: React.FC = () => {
                   title="Open private voice room"
                 >
                   <Video className="h-5 w-5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => handleRemoveFriend(friend)}
+                  title="Remove friend"
+                >
+                  <Trash2 className="h-5 w-5 text-red-500" />
                 </Button>
               </div>
             </div>

--- a/src/pages/FriendsPage.tsx
+++ b/src/pages/FriendsPage.tsx
@@ -159,7 +159,9 @@ const FriendsPage: React.FC = () => {
       await requestFriend(targetUser.username, token);
       setSuccess(`Заявка в друзья для ${targetUser.username} отправлена`);
       setTimeout(() => setSuccess(""), 3000);
-      setSearchResults((prev) => prev.filter((foundUser) => foundUser.id !== targetUser.id));
+      abortRef.current?.abort();
+      setIsSearching(false);
+      setSearchResults([]);
       setSearchQuery("");
     } catch (err: any) {
       setError(err.message || "Failed to send friend request");

--- a/src/pages/FriendsPage.tsx
+++ b/src/pages/FriendsPage.tsx
@@ -16,7 +16,7 @@ import {
 import { FriendRequest, Friend, UserInfo } from "../types";
 
 const FriendsPage: React.FC = () => {
-  const { token } = useAuth();
+  const { token, user: currentUser } = useAuth();
   const navigate = useNavigate();
   const { initiateCall, state: callState } = useCall();
 
@@ -93,7 +93,10 @@ const FriendsPage: React.FC = () => {
       try {
         const results = await searchUsers(q, token, controller.signal);
         const filtered = results.filter(
-          (user) => !friends.some((friend) => friend.username === user.username)
+          (user) =>
+            user.username !== currentUser?.username &&
+            user.id !== currentUser?.id &&
+            !friends.some((friend) => friend.username === user.username)
         );
         setSearchResults(filtered);
         setError("");
@@ -109,7 +112,7 @@ const FriendsPage: React.FC = () => {
         }
       }
     },
-    [token, friends]
+    [token, friends, currentUser]
   );
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -145,11 +148,20 @@ const FriendsPage: React.FC = () => {
 
   const handleSendFriendRequest = async (targetUser: { id: number; username: string }) => {
     if (!token) return;
+    if (
+      targetUser.username === currentUser?.username ||
+      targetUser.id === currentUser?.id
+    ) {
+      setError("Нельзя добавить себя в друзья");
+      return;
+    }
     try {
-      await requestFriend(targetUser.id, token);
-      setSuccess(`Friend request sent to ${targetUser.username}`);
+      await requestFriend(targetUser.username, token);
+      await loadData();
+      setSuccess(`${targetUser.username} добавлен в друзья`);
       setTimeout(() => setSuccess(""), 3000);
       setSearchResults((prev) => prev.filter((foundUser) => foundUser.id !== targetUser.id));
+      setSearchQuery("");
     } catch (err: any) {
       setError(err.message || "Failed to send friend request");
     }
@@ -158,7 +170,7 @@ const FriendsPage: React.FC = () => {
   const handleAcceptFriendRequest = async (request: FriendRequest) => {
     if (!token) return;
     try {
-      await acceptFriendRequest(Number(request.from_user_id), token);
+      await acceptFriendRequest(request.id, token);
       await loadData();
       setSuccess("Friend request accepted");
       setTimeout(() => setSuccess(""), 3000);
@@ -170,7 +182,7 @@ const FriendsPage: React.FC = () => {
   const handleDeclineFriendRequest = async (request: FriendRequest) => {
     if (!token) return;
     try {
-      await declineFriendRequest(Number(request.from_user_id), token);
+      await declineFriendRequest(request.id, token);
       await loadData();
       setSuccess("Friend request declined");
       setTimeout(() => setSuccess(""), 3000);
@@ -223,7 +235,7 @@ const FriendsPage: React.FC = () => {
               >
                 <span>{user.username}</span>
                 <Button variant="primary" size="sm" onClick={() => handleSendFriendRequest(user)}>
-                  Отправить заявку
+                  Добавить в друзья
                 </Button>
               </div>
             ))}
@@ -260,7 +272,7 @@ const FriendsPage: React.FC = () => {
 
       <div className="grid gap-4">
         {friends.length === 0 ? (
-          <p className="text-gray-500">Нет друзей. Отправьте заявку, чтобы добавить друзей.</p>
+          <p className="text-gray-500">Нет друзей. Найдите пользователя и добавьте его в друзья.</p>
         ) : (
           friends.map((friend) => (
             <div

--- a/src/pages/FriendsPage.tsx
+++ b/src/pages/FriendsPage.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from "react-router-dom";
 import { MessageCircle, Video } from "lucide-react";
 
 import { useAuth } from "../context/AuthContext";
-import { useCall } from "../context/CallContext";
 import Button from "../components/Button";
 import {
   fetchFriendRequests,
@@ -13,12 +12,12 @@ import {
   fetchFriends,
   searchUsers,
 } from "../services/friends-api";
+import { getOrCreateDirectRoom } from "../services/rooms-api";
 import { FriendRequest, Friend, UserInfo } from "../types";
 
 const FriendsPage: React.FC = () => {
   const { token, user: currentUser } = useAuth();
   const navigate = useNavigate();
-  const { initiateCall, state: callState } = useCall();
 
   const [friends, setFriends] = useState<Friend[]>([]);
   const [friendRequests, setFriendRequests] = useState<FriendRequest[]>([]);
@@ -157,8 +156,7 @@ const FriendsPage: React.FC = () => {
     }
     try {
       await requestFriend(targetUser.username, token);
-      await loadData();
-      setSuccess(`${targetUser.username} добавлен в друзья`);
+      setSuccess(`Заявка в друзья для ${targetUser.username} отправлена`);
       setTimeout(() => setSuccess(""), 3000);
       setSearchResults((prev) => prev.filter((foundUser) => foundUser.id !== targetUser.id));
       setSearchQuery("");
@@ -197,11 +195,18 @@ const FriendsPage: React.FC = () => {
     });
   };
 
-  const handleVideoCall = (friend: Friend) => {
-    initiateCall("direct", friend.friend_user_id, friend.username);
-  };
+  const handleVideoCall = async (friend: Friend) => {
+    if (!token) return;
 
-  const canMakeCall = callState.status === "idle" || callState.status === "ended";
+    try {
+      const room = await getOrCreateDirectRoom(friend.friend_user_id, token);
+      navigate(`/room/${encodeURIComponent(room.room_id)}`, {
+        state: { roomName: `Private voice with ${friend.username}` },
+      });
+    } catch (err: any) {
+      setError(err.message || "Failed to open private voice room");
+    }
+  };
 
   return (
     <div className="min-h-screen flex flex-col p-6">
@@ -288,8 +293,7 @@ const FriendsPage: React.FC = () => {
                   variant="secondary"
                   size="sm"
                   onClick={() => handleVideoCall(friend)}
-                  disabled={!canMakeCall}
-                  title={canMakeCall ? "Video call" : "Already in a call"}
+                  title="Open private voice room"
                 >
                   <Video className="h-5 w-5" />
                 </Button>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,15 +8,14 @@ import {
   deleteRoom,
   updateRoom,
   inviteFriendToRoom,
+  getOrCreateDirectRoom,
 } from "../services/rooms-api";
 import { fetchFriends } from "../services/friends-api";
 import { Room, Friend } from "../types";
-import { useCall } from "../context/CallContext";
 import { useNavigate } from "react-router-dom";
 
 const Index: React.FC = () => {
   const { token } = useAuth();
-  const { initiateCall, state: callState } = useCall();
   const navigate = useNavigate();
   const [rooms, setRooms] = useState<Room[]>([]);
   const [invitedRooms, setInvitedRooms] = useState<Room[]>([]);
@@ -131,7 +130,7 @@ const Index: React.FC = () => {
       <main className="flex-1 overflow-auto p-6">
         <div className="flex items-center justify-between mb-8">
           <h1 className="text-2xl font-bold">Welcome to VideoChat</h1>
-          <Button variant="primary">
+          <Button variant="primary" onClick={() => navigate("/rooms")}>
             <Plus className="h-4 w-4 mr-2" />
             Create Room
           </Button>
@@ -223,7 +222,6 @@ const Index: React.FC = () => {
           ) : (
             <div className="grid gap-2">
               {friends.map((friend) => {
-                const canMakeCall = callState.status === 'idle' || callState.status === 'ended';
                 return (
                   <div
                     key={friend.id}
@@ -236,11 +234,20 @@ const Index: React.FC = () => {
                     <Button
                       variant="ghost"
                       size="sm"
-                      disabled={!canMakeCall}
-                      onClick={() => initiateCall('direct', friend.friend_user_id, friend.username)}
+                      onClick={async () => {
+                        if (!token) return;
+                        try {
+                          const room = await getOrCreateDirectRoom(friend.friend_user_id, token);
+                          navigate(`/room/${encodeURIComponent(room.room_id)}`, {
+                            state: { roomName: `Private voice with ${friend.username}` },
+                          });
+                        } catch (error) {
+                          console.error("Failed to open private room:", error);
+                        }
+                      }}
                     >
                       <Video className="h-4 w-4 mr-2" />
-                      Call
+                      Voice Room
                     </Button>
                   </div>
                 );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -103,8 +103,8 @@ const Index: React.FC = () => {
 
   // Обработка присоединения к комнате - navigate using room name
   const handleJoinRoom = (room: Room) => {
-    navigate(`/room/${encodeURIComponent(room.name)}`, {
-      state: { roomId: parseInt(room.room_id, 10) }
+    navigate(`/room/${encodeURIComponent(room.room_id)}`, {
+      state: { roomName: room.name }
     });
   };
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -15,7 +15,7 @@ import { Room, Friend } from "../types";
 import { useNavigate } from "react-router-dom";
 
 const Index: React.FC = () => {
-  const { token } = useAuth();
+  const { token, user } = useAuth();
   const navigate = useNavigate();
   const [rooms, setRooms] = useState<Room[]>([]);
   const [invitedRooms, setInvitedRooms] = useState<Room[]>([]);
@@ -34,7 +34,10 @@ const Index: React.FC = () => {
         const fetchedFriends = await fetchFriends(token);
 
         // Помечаем, какие комнаты созданы пользователем
-        const markedOwnRooms = ownRooms.map((room) => ({ ...room, is_owner: true }));
+        const markedOwnRooms = ownRooms.map((room) => ({
+          ...room,
+          is_owner: room.user_id === user?.user_id,
+        }));
         const markedInvitedRooms = invited.map((room) => ({ ...room, is_owner: false }));
 
         setRooms(markedOwnRooms);
@@ -45,9 +48,11 @@ const Index: React.FC = () => {
       }
     };
     loadData();
-  }, [token]);
+  }, [token, user?.user_id]);
 
   const allRooms: Room[] = [...rooms, ...invitedRooms];
+  const getRoomDisplayName = (room: Room) =>
+    room.name.startsWith("__direct__:") ? "Private voice room" : room.name;
 
   // Удаление комнаты
   const handleDeleteRoom = async (roomId: string) => {
@@ -155,7 +160,7 @@ const Index: React.FC = () => {
                   }`}
                 >
                   <div className="mb-2">
-                    <h3 className="font-medium">{room.name}</h3>
+                    <h3 className="font-medium">{getRoomDisplayName(room)}</h3>
                   </div>
                   <div className="flex justify-between items-center">
                     <Button

--- a/src/pages/LoginSignupPage.tsx
+++ b/src/pages/LoginSignupPage.tsx
@@ -19,6 +19,11 @@ const LoginSignupPage: React.FC = () => {
     setSuccessMessage("");
   };
 
+  const switchToLoginMode = () => {
+    setIsLogin(true);
+    setError("");
+  };
+
   const handleSubmit = async () => {
     try {
         setError("");
@@ -47,7 +52,7 @@ const LoginSignupPage: React.FC = () => {
         } else {
             await register(username, password);
             setSuccessMessage("Registration successful! You can now log in.");
-            toggleMode();
+            switchToLoginMode();
         }
     } catch (err: any) {
       setError(err.message || "Operation failed");

--- a/src/pages/RoomPage.tsx
+++ b/src/pages/RoomPage.tsx
@@ -66,46 +66,33 @@ const ControlButton: React.FC<ControlButtonProps> = ({
 const VoiceTile: React.FC<{
   participant: RoomVoiceParticipantState;
   isCurrentUser: boolean;
-  videoTrack?: Track;
+  cameraTrack?: Track;
   audioTrack?: Track;
   isCameraOff?: boolean;
-}> = ({ participant, isCurrentUser, videoTrack, audioTrack, isCameraOff = true }) => {
+}> = ({ participant, isCurrentUser, cameraTrack, audioTrack, isCameraOff = true }) => {
   const initials = (participant.name || participant.username || "?").slice(0, 1).toUpperCase();
   const videoRef = useRef<HTMLVideoElement>(null);
   const audioRef = useRef<HTMLAudioElement>(null);
-  const hasVideoTrack = Boolean(videoTrack);
-  const showVideo = participant.is_screen_sharing || (hasVideoTrack && !isCameraOff);
+  const hasVideoTrack = Boolean(cameraTrack);
+  const showVideo = hasVideoTrack && !isCameraOff;
   const statusLabel = participant.is_screen_sharing
-    ? "Screen sharing"
+    ? "Sharing screen"
     : showVideo
       ? "Camera on"
       : "Voice only";
 
   useEffect(() => {
-    if (!videoRef.current || !videoTrack || participant.is_screen_sharing) {
+    if (!videoRef.current || !cameraTrack || !showVideo) {
       return undefined;
     }
 
-    const track = videoTrack as VideoTrack;
+    const track = cameraTrack as VideoTrack;
     track.attach(videoRef.current);
 
     return () => {
       track.detach(videoRef.current!);
     };
-  }, [participant.is_screen_sharing, videoTrack]);
-
-  useEffect(() => {
-    if (!videoRef.current || !videoTrack || !participant.is_screen_sharing) {
-      return undefined;
-    }
-
-    const track = videoTrack as VideoTrack;
-    track.attach(videoRef.current);
-
-    return () => {
-      track.detach(videoRef.current!);
-    };
-  }, [participant.is_screen_sharing, videoTrack]);
+  }, [cameraTrack, showVideo]);
 
   useEffect(() => {
     if (isCurrentUser || !audioRef.current || !audioTrack) {
@@ -170,6 +157,52 @@ const VoiceTile: React.FC<{
   );
 };
 
+const ScreenShareTile: React.FC<{
+  participant: RoomVoiceParticipantState;
+  screenShareTrack?: Track;
+}> = ({ participant, screenShareTrack }) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (!videoRef.current || !screenShareTrack) {
+      return undefined;
+    }
+
+    const track = screenShareTrack as VideoTrack;
+    track.attach(videoRef.current);
+
+    return () => {
+      track.detach(videoRef.current!);
+    };
+  }, [screenShareTrack]);
+
+  if (!screenShareTrack) {
+    return null;
+  }
+
+  return (
+    <div className="relative rounded-xl overflow-hidden bg-gray-950 aspect-video shadow-lg ring-1 ring-blue-400/40">
+      <video
+        ref={videoRef}
+        autoPlay
+        playsInline
+        muted
+        className="w-full h-full object-contain bg-black"
+      />
+
+      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent p-3">
+        <div className="flex items-center justify-between">
+          <div className="text-white">
+            <div className="font-medium">{participant.username} is sharing</div>
+            <div className="text-xs text-white/70">Screen share</div>
+          </div>
+          <Monitor className="w-4 h-4 text-blue-300" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
 export default function RoomPage(): JSX.Element {
   const { roomID } = useParams();
   const navigate = useNavigate();
@@ -184,6 +217,7 @@ export default function RoomPage(): JSX.Element {
     toggleRoomVoiceScreenShare,
     clearRoomVoiceError,
     getLocalVideoTrack,
+    getLocalScreenShareTrack,
   } = useRoomVoice();
 
   const routeRoomName =
@@ -278,9 +312,56 @@ export default function RoomPage(): JSX.Element {
     [roomVoiceState.participants]
   );
   const localVideoTrack = getLocalVideoTrack();
+  const localScreenShareTrack = getLocalScreenShareTrack();
   const myVoiceState = useMemo(
     () => voiceParticipants.find((participant) => participant.user_id === user?.user_id) ?? null,
     [voiceParticipants, user?.user_id]
+  );
+  const displayedVoiceParticipants = voiceParticipants.length > 0
+    ? voiceParticipants
+    : isCurrentRoomSession && user
+      ? [{
+          id: user.id,
+          user_id: user.user_id,
+          username: user.username,
+          name: user.name,
+          is_online: user.is_online,
+          is_mic_enabled: !roomVoiceState.localMuted,
+          is_camera_enabled: !roomVoiceState.localCameraOff,
+          is_screen_sharing: roomVoiceState.screenSharing,
+          joined_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }]
+      : [];
+
+  const screenShareTiles = useMemo(
+    () =>
+      displayedVoiceParticipants
+        .map((participant) => {
+          const liveParticipant = liveParticipantsByUserId.get(participant.user_id);
+          const screenShareTrack =
+            participant.user_id === user?.user_id
+              ? localScreenShareTrack ?? liveParticipant?.screenShareTrack
+              : liveParticipant?.screenShareTrack;
+
+          if (!screenShareTrack) {
+            return null;
+          }
+
+          return {
+            participant,
+            screenShareTrack,
+          };
+        })
+        .filter(
+          (
+            tile
+          ): tile is {
+            participant: RoomVoiceParticipantState;
+            screenShareTrack: Track;
+          } => tile !== null
+        ),
+    [displayedVoiceParticipants, liveParticipantsByUserId, localScreenShareTrack, user?.user_id]
   );
 
   const canToggleMedia = isCurrentRoomSession && roomVoiceState.status === "active" && !isSubmitting;
@@ -358,30 +439,13 @@ export default function RoomPage(): JSX.Element {
   }, [clearRoomVoiceError, roomVoiceState.error]);
 
   const getGridClass = () => {
-    const count = Math.max(displayedVoiceParticipants.length, 1);
+    const count = Math.max(displayedVoiceParticipants.length + screenShareTiles.length, 1);
     if (count <= 1) return "grid-cols-1";
     if (count === 2) return "grid-cols-2";
     if (count <= 4) return "grid-cols-2";
     if (count <= 6) return "grid-cols-3";
     return "grid-cols-4";
   };
-
-  const displayedVoiceParticipants = voiceParticipants.length > 0
-    ? voiceParticipants
-    : isCurrentRoomSession && user
-      ? [{
-          id: user.id,
-          user_id: user.user_id,
-          username: user.username,
-          name: user.name,
-          is_online: user.is_online,
-          is_mic_enabled: !roomVoiceState.localMuted,
-          is_camera_enabled: !roomVoiceState.localCameraOff,
-          is_screen_sharing: roomVoiceState.screenSharing,
-          joined_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
-        }]
-      : [];
 
   if (isLoading) {
     return (
@@ -487,12 +551,19 @@ export default function RoomPage(): JSX.Element {
                     participant={participant}
                     isCurrentUser={participant.user_id === user?.user_id}
                     isCameraOff={liveParticipantsByUserId.get(participant.user_id)?.isCameraOff}
-                    videoTrack={
+                    cameraTrack={
                       participant.user_id === user?.user_id
-                        ? localVideoTrack ?? liveParticipantsByUserId.get(participant.user_id)?.videoTrack
-                        : liveParticipantsByUserId.get(participant.user_id)?.videoTrack
+                        ? localVideoTrack ?? liveParticipantsByUserId.get(participant.user_id)?.cameraTrack
+                        : liveParticipantsByUserId.get(participant.user_id)?.cameraTrack
                     }
                     audioTrack={liveParticipantsByUserId.get(participant.user_id)?.audioTrack}
+                  />
+                ))}
+                {screenShareTiles.map(({ participant, screenShareTrack }) => (
+                  <ScreenShareTile
+                    key={`${participant.user_id}-screen-share`}
+                    participant={participant}
+                    screenShareTrack={screenShareTrack}
                   />
                 ))}
               </div>

--- a/src/pages/RoomPage.tsx
+++ b/src/pages/RoomPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import {
   ArrowLeft,
@@ -13,16 +13,15 @@ import {
   Radio,
 } from "lucide-react";
 import { motion } from "framer-motion";
+import { AudioTrack, Track, VideoTrack } from "livekit-client";
 
 import { useAuth } from "../context/AuthContext";
+import { useRoomVoice } from "../context/RoomVoiceContext";
 import {
   fetchRoomState,
   joinRoomAsMember,
-  joinRoomVoice,
-  leaveRoomVoice,
   RoomStateResponse,
   RoomVoiceParticipantState,
-  updateRoomVoiceMedia,
 } from "../services/rooms-api";
 
 interface ControlButtonProps {
@@ -67,16 +66,70 @@ const ControlButton: React.FC<ControlButtonProps> = ({
 const VoiceTile: React.FC<{
   participant: RoomVoiceParticipantState;
   isCurrentUser: boolean;
-}> = ({ participant, isCurrentUser }) => {
+  videoTrack?: Track;
+  audioTrack?: Track;
+}> = ({ participant, isCurrentUser, videoTrack, audioTrack }) => {
   const initials = (participant.name || participant.username || "?").slice(0, 1).toUpperCase();
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  useEffect(() => {
+    if (!videoRef.current || !videoTrack || participant.is_screen_sharing) {
+      return undefined;
+    }
+
+    const track = videoTrack as VideoTrack;
+    track.attach(videoRef.current);
+
+    return () => {
+      track.detach(videoRef.current!);
+    };
+  }, [participant.is_screen_sharing, videoTrack]);
+
+  useEffect(() => {
+    if (!videoRef.current || !videoTrack || !participant.is_screen_sharing) {
+      return undefined;
+    }
+
+    const track = videoTrack as VideoTrack;
+    track.attach(videoRef.current);
+
+    return () => {
+      track.detach(videoRef.current!);
+    };
+  }, [participant.is_screen_sharing, videoTrack]);
+
+  useEffect(() => {
+    if (isCurrentUser || !audioRef.current || !audioTrack) {
+      return undefined;
+    }
+
+    const track = audioTrack as AudioTrack;
+    track.attach(audioRef.current);
+
+    return () => {
+      track.detach(audioRef.current!);
+    };
+  }, [audioTrack, isCurrentUser]);
 
   return (
     <div className="relative rounded-xl overflow-hidden bg-gray-800 aspect-video shadow-lg">
-      <div className="w-full h-full flex items-center justify-center">
-        <div className="w-16 h-16 rounded-full bg-primary/30 flex items-center justify-center">
-          <span className="text-2xl font-bold text-white">{initials}</span>
+      {!isCurrentUser && <audio ref={audioRef} autoPlay playsInline />}
+      {videoTrack && (participant.is_camera_enabled || participant.is_screen_sharing) ? (
+        <video
+          ref={videoRef}
+          autoPlay
+          playsInline
+          muted={isCurrentUser}
+          className="w-full h-full object-cover"
+        />
+      ) : (
+        <div className="w-full h-full flex items-center justify-center">
+          <div className="w-16 h-16 rounded-full bg-primary/30 flex items-center justify-center">
+            <span className="text-2xl font-bold text-white">{initials}</span>
+          </div>
         </div>
-      </div>
+      )}
 
       <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-3">
         <div className="flex items-center justify-between">
@@ -120,6 +173,15 @@ export default function RoomPage(): JSX.Element {
   const navigate = useNavigate();
   const location = useLocation();
   const { token, user } = useAuth();
+  const {
+    state: roomVoiceState,
+    joinRoomVoiceSession,
+    leaveRoomVoiceSession,
+    toggleRoomVoiceMic,
+    toggleRoomVoiceCamera,
+    toggleRoomVoiceScreenShare,
+    clearRoomVoiceError,
+  } = useRoomVoice();
 
   const routeRoomName =
     (location.state as { roomName?: string } | null)?.roomName ??
@@ -186,19 +248,28 @@ export default function RoomPage(): JSX.Element {
   const roomName = roomState?.room.name || routeRoomName;
   const voiceParticipants = roomState?.voice_participants ?? [];
   const members = roomState?.members ?? [];
-  const inVoice = roomState?.in_voice ?? false;
+  const isCurrentRoomSession =
+    roomVoiceState.roomId === roomIdentifier && roomVoiceState.status !== "idle";
+  const inVoice = Boolean(roomState?.in_voice) || isCurrentRoomSession;
+  const liveParticipantsByUserId = useMemo(
+    () =>
+      new Map(
+        roomVoiceState.participants.map((participant) => [participant.identity, participant])
+      ),
+    [roomVoiceState.participants]
+  );
   const myVoiceState = useMemo(
     () => voiceParticipants.find((participant) => participant.user_id === user?.user_id) ?? null,
     [voiceParticipants, user?.user_id]
   );
 
-  const canToggleMedia = inVoice && !isSubmitting;
+  const canToggleMedia = isCurrentRoomSession && roomVoiceState.status === "active" && !isSubmitting;
 
   const handleJoinVoice = async () => {
     if (!token || !roomIdentifier) return;
     setIsSubmitting(true);
     try {
-      await joinRoomVoice(roomIdentifier, token);
+      await joinRoomVoiceSession(roomIdentifier, roomName || routeRoomName || roomIdentifier);
       await loadRoomState();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to join voice");
@@ -208,10 +279,10 @@ export default function RoomPage(): JSX.Element {
   };
 
   const handleLeaveVoice = async () => {
-    if (!token || !roomIdentifier) return;
+    if (!roomIdentifier) return;
     setIsSubmitting(true);
     try {
-      await leaveRoomVoice(roomIdentifier, token);
+      await leaveRoomVoiceSession(roomIdentifier);
       await loadRoomState();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to leave voice");
@@ -220,33 +291,77 @@ export default function RoomPage(): JSX.Element {
     }
   };
 
-  const handleUpdateMedia = async (
-    patch: Partial<{
-      is_mic_enabled: boolean;
-      is_camera_enabled: boolean;
-      is_screen_sharing: boolean;
-    }>
-  ) => {
-    if (!token || !roomIdentifier || !inVoice) return;
+  const handleToggleMic = async () => {
+    if (!isCurrentRoomSession) return;
     setIsSubmitting(true);
     try {
-      await updateRoomVoiceMedia(roomIdentifier, patch, token);
+      await toggleRoomVoiceMic();
       await loadRoomState();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to update media state");
+      setError(err instanceof Error ? err.message : "Failed to toggle microphone");
     } finally {
       setIsSubmitting(false);
     }
   };
 
+  const handleToggleCamera = async () => {
+    if (!isCurrentRoomSession) return;
+    setIsSubmitting(true);
+    try {
+      await toggleRoomVoiceCamera();
+      await loadRoomState();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to toggle camera");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleToggleScreenShare = async () => {
+    if (!isCurrentRoomSession) return;
+    setIsSubmitting(true);
+    try {
+      await toggleRoomVoiceScreenShare();
+      await loadRoomState();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to toggle screen share");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  useEffect(() => {
+    if (roomVoiceState.error) {
+      setError(roomVoiceState.error);
+      clearRoomVoiceError();
+    }
+  }, [clearRoomVoiceError, roomVoiceState.error]);
+
   const getGridClass = () => {
-    const count = Math.max(voiceParticipants.length, 1);
+    const count = Math.max(displayedVoiceParticipants.length, 1);
     if (count <= 1) return "grid-cols-1";
     if (count === 2) return "grid-cols-2";
     if (count <= 4) return "grid-cols-2";
     if (count <= 6) return "grid-cols-3";
     return "grid-cols-4";
   };
+
+  const displayedVoiceParticipants = voiceParticipants.length > 0
+    ? voiceParticipants
+    : isCurrentRoomSession && user
+      ? [{
+          id: user.id,
+          user_id: user.user_id,
+          username: user.username,
+          name: user.name,
+          is_online: user.is_online,
+          is_mic_enabled: !roomVoiceState.localMuted,
+          is_camera_enabled: !roomVoiceState.localCameraOff,
+          is_screen_sharing: roomVoiceState.screenSharing,
+          joined_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }]
+      : [];
 
   if (isLoading) {
     return (
@@ -287,7 +402,7 @@ export default function RoomPage(): JSX.Element {
           <div>
             <h1 className="text-lg font-semibold text-white">Room: {roomName}</h1>
             <p className="text-sm text-white/70">
-              {members.length} members, {voiceParticipants.length} in voice
+              {members.length} members, {displayedVoiceParticipants.length} in voice
             </p>
           </div>
         </div>
@@ -322,7 +437,7 @@ export default function RoomPage(): JSX.Element {
       <main className="flex-1 overflow-hidden">
         <div className="h-full flex flex-col">
           <div className="flex-1 p-4 overflow-auto">
-            {voiceParticipants.length === 0 ? (
+              {displayedVoiceParticipants.length === 0 ? (
               <div className="h-full flex items-center justify-center">
                 <div className="text-center max-w-md p-8">
                   <div className="w-20 h-20 rounded-full bg-gray-800 flex items-center justify-center mx-auto mb-6">
@@ -346,11 +461,13 @@ export default function RoomPage(): JSX.Element {
               </div>
             ) : (
               <div className={`grid ${getGridClass()} gap-4 h-full`}>
-                {voiceParticipants.map((participant) => (
+                {displayedVoiceParticipants.map((participant) => (
                   <VoiceTile
                     key={participant.user_id}
                     participant={participant}
                     isCurrentUser={participant.user_id === user?.user_id}
+                    videoTrack={liveParticipantsByUserId.get(participant.user_id)?.videoTrack}
+                    audioTrack={liveParticipantsByUserId.get(participant.user_id)?.audioTrack}
                   />
                 ))}
               </div>
@@ -361,7 +478,7 @@ export default function RoomPage(): JSX.Element {
             <h2 className="text-sm font-semibold text-white/80 mb-2">Room Members</h2>
             <div className="flex flex-wrap gap-2">
               {members.map((member) => {
-                const isInVoice = voiceParticipants.some(
+                const isInVoice = displayedVoiceParticipants.some(
                   (participant) => participant.user_id === member.user_id
                 );
                 return (
@@ -388,36 +505,36 @@ export default function RoomPage(): JSX.Element {
             <ControlButton
               icon={<Mic className="w-5 h-5 text-white" />}
               activeIcon={<MicOff className="w-5 h-5 text-red-400" />}
-              isActive={!myVoiceState?.is_mic_enabled}
+              isActive={isCurrentRoomSession ? roomVoiceState.localMuted : !myVoiceState?.is_mic_enabled}
               disabled={!canToggleMedia}
-              onClick={() =>
-                void handleUpdateMedia({ is_mic_enabled: !myVoiceState?.is_mic_enabled })
-              }
-              label={myVoiceState?.is_mic_enabled ? "Mute" : "Unmute"}
+              onClick={() => void handleToggleMic()}
+              label={isCurrentRoomSession && roomVoiceState.localMuted ? "Unmute" : "Mute"}
             />
 
             <ControlButton
               icon={<Video className="w-5 h-5 text-white" />}
               activeIcon={<VideoOff className="w-5 h-5 text-red-400" />}
-              isActive={!myVoiceState?.is_camera_enabled}
+              isActive={isCurrentRoomSession ? roomVoiceState.localCameraOff : !myVoiceState?.is_camera_enabled}
               disabled={!canToggleMedia}
-              onClick={() =>
-                void handleUpdateMedia({ is_camera_enabled: !myVoiceState?.is_camera_enabled })
+              onClick={() => void handleToggleCamera()}
+              label={
+                isCurrentRoomSession && roomVoiceState.localCameraOff
+                  ? "Turn on camera"
+                  : "Turn off camera"
               }
-              label={myVoiceState?.is_camera_enabled ? "Turn off camera" : "Turn on camera"}
             />
 
             <ControlButton
               icon={<Monitor className="w-5 h-5 text-white" />}
               activeIcon={<MonitorOff className="w-5 h-5 text-red-400" />}
-              isActive={Boolean(myVoiceState?.is_screen_sharing)}
+              isActive={isCurrentRoomSession ? roomVoiceState.screenSharing : Boolean(myVoiceState?.is_screen_sharing)}
               disabled={!canToggleMedia}
-              onClick={() =>
-                void handleUpdateMedia({
-                  is_screen_sharing: !myVoiceState?.is_screen_sharing,
-                })
+              onClick={() => void handleToggleScreenShare()}
+              label={
+                isCurrentRoomSession && roomVoiceState.screenSharing
+                  ? "Stop sharing"
+                  : "Share screen"
               }
-              label={myVoiceState?.is_screen_sharing ? "Stop sharing" : "Share screen"}
             />
 
             <ControlButton

--- a/src/pages/RoomPage.tsx
+++ b/src/pages/RoomPage.tsx
@@ -193,6 +193,22 @@ export default function RoomPage(): JSX.Element {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const getRoomDisplayName = useCallback(
+    (rawName: string, membersList: RoomStateResponse["members"]) => {
+      if (!rawName.startsWith("__direct__:")) {
+        return rawName;
+      }
+
+      const otherMember = membersList.find((member) => member.user_id !== user?.user_id);
+      if (otherMember?.username) {
+        return `Private voice with ${otherMember.username}`;
+      }
+
+      return routeRoomName || "Private voice room";
+    },
+    [routeRoomName, user?.user_id]
+  );
+
   const loadRoomState = useCallback(async () => {
     if (!token || !roomIdentifier) return;
 
@@ -245,7 +261,7 @@ export default function RoomPage(): JSX.Element {
     return () => clearInterval(interval);
   }, [loadRoomState, roomIdentifier, token]);
 
-  const roomName = roomState?.room.name || routeRoomName;
+  const roomName = getRoomDisplayName(roomState?.room.name || routeRoomName, roomState?.members ?? []);
   const voiceParticipants = roomState?.voice_participants ?? [];
   const members = roomState?.members ?? [];
   const isCurrentRoomSession =

--- a/src/pages/RoomPage.tsx
+++ b/src/pages/RoomPage.tsx
@@ -203,6 +203,7 @@ const ScreenShareTile: React.FC<{
   );
 };
 
+// RoomPage renders room membership, room voice controls, and room media tiles.
 export default function RoomPage(): JSX.Element {
   const { roomID } = useParams();
   const navigate = useNavigate();

--- a/src/pages/RoomPage.tsx
+++ b/src/pages/RoomPage.tsx
@@ -68,10 +68,18 @@ const VoiceTile: React.FC<{
   isCurrentUser: boolean;
   videoTrack?: Track;
   audioTrack?: Track;
-}> = ({ participant, isCurrentUser, videoTrack, audioTrack }) => {
+  isCameraOff?: boolean;
+}> = ({ participant, isCurrentUser, videoTrack, audioTrack, isCameraOff = true }) => {
   const initials = (participant.name || participant.username || "?").slice(0, 1).toUpperCase();
   const videoRef = useRef<HTMLVideoElement>(null);
   const audioRef = useRef<HTMLAudioElement>(null);
+  const hasVideoTrack = Boolean(videoTrack);
+  const showVideo = participant.is_screen_sharing || (hasVideoTrack && !isCameraOff);
+  const statusLabel = participant.is_screen_sharing
+    ? "Screen sharing"
+    : showVideo
+      ? "Camera on"
+      : "Voice only";
 
   useEffect(() => {
     if (!videoRef.current || !videoTrack || participant.is_screen_sharing) {
@@ -115,7 +123,7 @@ const VoiceTile: React.FC<{
   return (
     <div className="relative rounded-xl overflow-hidden bg-gray-800 aspect-video shadow-lg">
       {!isCurrentUser && <audio ref={audioRef} autoPlay playsInline />}
-      {videoTrack && (participant.is_camera_enabled || participant.is_screen_sharing) ? (
+      {showVideo ? (
         <video
           ref={videoRef}
           autoPlay
@@ -135,13 +143,7 @@ const VoiceTile: React.FC<{
         <div className="flex items-center justify-between">
           <div className="text-white">
             <div className="font-medium">{isCurrentUser ? "You" : participant.username}</div>
-            <div className="text-xs text-white/70">
-              {participant.is_screen_sharing
-                ? "Screen sharing"
-                : participant.is_camera_enabled
-                  ? "Camera on"
-                  : "Voice only"}
-            </div>
+            <div className="text-xs text-white/70">{statusLabel}</div>
           </div>
           <div className="flex items-center gap-2">
             {participant.is_mic_enabled ? (
@@ -149,10 +151,10 @@ const VoiceTile: React.FC<{
             ) : (
               <MicOff className="w-4 h-4 text-red-400" />
             )}
-            {participant.is_camera_enabled ? (
+            {showVideo ? (
               <Video className="w-4 h-4 text-green-300" />
             ) : (
-              <VideoOff className="w-4 h-4 text-white/50" />
+              <VideoOff className="w-4 h-4 text-red-400" />
             )}
             {participant.is_screen_sharing && <Monitor className="w-4 h-4 text-blue-300" />}
           </div>
@@ -181,6 +183,7 @@ export default function RoomPage(): JSX.Element {
     toggleRoomVoiceCamera,
     toggleRoomVoiceScreenShare,
     clearRoomVoiceError,
+    getLocalVideoTrack,
   } = useRoomVoice();
 
   const routeRoomName =
@@ -274,6 +277,7 @@ export default function RoomPage(): JSX.Element {
       ),
     [roomVoiceState.participants]
   );
+  const localVideoTrack = getLocalVideoTrack();
   const myVoiceState = useMemo(
     () => voiceParticipants.find((participant) => participant.user_id === user?.user_id) ?? null,
     [voiceParticipants, user?.user_id]
@@ -482,7 +486,12 @@ export default function RoomPage(): JSX.Element {
                     key={participant.user_id}
                     participant={participant}
                     isCurrentUser={participant.user_id === user?.user_id}
-                    videoTrack={liveParticipantsByUserId.get(participant.user_id)?.videoTrack}
+                    isCameraOff={liveParticipantsByUserId.get(participant.user_id)?.isCameraOff}
+                    videoTrack={
+                      participant.user_id === user?.user_id
+                        ? localVideoTrack ?? liveParticipantsByUserId.get(participant.user_id)?.videoTrack
+                        : liveParticipantsByUserId.get(participant.user_id)?.videoTrack
+                    }
                     audioTrack={liveParticipantsByUserId.get(participant.user_id)?.audioTrack}
                   />
                 ))}
@@ -519,8 +528,8 @@ export default function RoomPage(): JSX.Element {
             className="flex items-center justify-center gap-4 p-4 bg-gray-800 border-t border-gray-700"
           >
             <ControlButton
-              icon={<Mic className="w-5 h-5 text-white" />}
-              activeIcon={<MicOff className="w-5 h-5 text-red-400" />}
+              icon={<MicOff className="w-5 h-5 text-red-400" />}
+              activeIcon={<Mic className="w-5 h-5 text-white" />}
               isActive={isCurrentRoomSession ? roomVoiceState.localMuted : !myVoiceState?.is_mic_enabled}
               disabled={!canToggleMedia}
               onClick={() => void handleToggleMic()}
@@ -528,8 +537,8 @@ export default function RoomPage(): JSX.Element {
             />
 
             <ControlButton
-              icon={<Video className="w-5 h-5 text-white" />}
-              activeIcon={<VideoOff className="w-5 h-5 text-red-400" />}
+              icon={<VideoOff className="w-5 h-5 text-red-400" />}
+              activeIcon={<Video className="w-5 h-5 text-white" />}
               isActive={isCurrentRoomSession ? roomVoiceState.localCameraOff : !myVoiceState?.is_camera_enabled}
               disabled={!canToggleMedia}
               onClick={() => void handleToggleCamera()}
@@ -541,9 +550,9 @@ export default function RoomPage(): JSX.Element {
             />
 
             <ControlButton
-              icon={<Monitor className="w-5 h-5 text-white" />}
-              activeIcon={<MonitorOff className="w-5 h-5 text-red-400" />}
-              isActive={isCurrentRoomSession ? roomVoiceState.screenSharing : Boolean(myVoiceState?.is_screen_sharing)}
+              icon={<MonitorOff className="w-5 h-5 text-red-400" />}
+              activeIcon={<Monitor className="w-5 h-5 text-white" />}
+              isActive={!(isCurrentRoomSession ? roomVoiceState.screenSharing : Boolean(myVoiceState?.is_screen_sharing))}
               disabled={!canToggleMedia}
               onClick={() => void handleToggleScreenShare()}
               label={

--- a/src/pages/RoomPage.tsx
+++ b/src/pages/RoomPage.tsx
@@ -1,112 +1,36 @@
-/**
- * Room Page
- * Video room using LiveKit for group calls
- */
-
-import { useEffect, useRef } from 'react';
-import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import {
+  ArrowLeft,
   Mic,
   MicOff,
+  Monitor,
+  MonitorOff,
+  Users,
   Video,
   VideoOff,
   PhoneOff,
-  Monitor,
-  Users,
-  ArrowLeft,
-} from 'lucide-react';
-import { motion } from 'framer-motion';
-import { useCall } from '../context/CallContext';
-import { useWebSocketContext } from '../context/WebSocketContext';
-import { useAuth } from '../context/AuthContext';
-import { joinRoomAsMember } from '../services/rooms-api';
-import { AudioTrack, VideoTrack } from 'livekit-client';
-import { ParticipantInfo } from '../services/livekit';
+  Radio,
+} from "lucide-react";
+import { motion } from "framer-motion";
 
-// Video tile for a participant
-interface VideoTileProps {
-  participant: ParticipantInfo;
-}
+import { useAuth } from "../context/AuthContext";
+import {
+  fetchRoomState,
+  joinRoomAsMember,
+  joinRoomVoice,
+  leaveRoomVoice,
+  RoomStateResponse,
+  RoomVoiceParticipantState,
+  updateRoomVoiceMedia,
+} from "../services/rooms-api";
 
-const VideoTile: React.FC<VideoTileProps> = ({ participant }) => {
-  const videoRef = useRef<HTMLVideoElement>(null);
-  const audioRef = useRef<HTMLAudioElement>(null);
-
-  useEffect(() => {
-    if (videoRef.current && participant.videoTrack) {
-      const videoTrack = participant.videoTrack as VideoTrack;
-      videoTrack.attach(videoRef.current);
-
-      return () => {
-        if (videoRef.current) {
-          videoTrack.detach(videoRef.current);
-        }
-      };
-    }
-  }, [participant.videoTrack]);
-
-  useEffect(() => {
-    if (participant.isLocal || !audioRef.current || !participant.audioTrack) {
-      return;
-    }
-
-    const audioTrack = participant.audioTrack as AudioTrack;
-    audioTrack.attach(audioRef.current);
-
-    return () => {
-      if (audioRef.current) {
-        audioTrack.detach(audioRef.current);
-      }
-    };
-  }, [participant.audioTrack, participant.isLocal]);
-
-  const hasVideo = participant.videoTrack && !participant.isCameraOff;
-
-  return (
-    <div className="relative rounded-xl overflow-hidden bg-gray-800 aspect-video shadow-lg">
-      {!participant.isLocal && <audio ref={audioRef} autoPlay playsInline />}
-      {hasVideo ? (
-        <video
-          ref={videoRef}
-          autoPlay
-          playsInline
-          muted={participant.isLocal}
-          className="w-full h-full object-cover"
-        />
-      ) : (
-        <div className="w-full h-full flex items-center justify-center">
-          <div className="w-16 h-16 rounded-full bg-primary/30 flex items-center justify-center">
-            <span className="text-2xl font-bold text-white">
-              {participant.name.charAt(0).toUpperCase()}
-            </span>
-          </div>
-        </div>
-      )}
-
-      {/* Name and status badge */}
-      <div className="absolute bottom-2 left-2 flex items-center gap-2 bg-black/50 rounded-lg px-2 py-1">
-        <span className="text-white text-sm font-medium">
-          {participant.isLocal ? 'You' : participant.name}
-        </span>
-        {participant.isMuted && <MicOff className="w-3 h-3 text-red-400" />}
-      </div>
-
-      {/* Local indicator */}
-      {participant.isLocal && (
-        <div className="absolute top-2 right-2 bg-primary rounded px-2 py-0.5">
-          <span className="text-xs font-medium text-white">You</span>
-        </div>
-      )}
-    </div>
-  );
-};
-
-// Control button component
 interface ControlButtonProps {
   icon: React.ReactNode;
   activeIcon?: React.ReactNode;
   isActive?: boolean;
   isDanger?: boolean;
+  disabled?: boolean;
   onClick: () => void;
   label: string;
 }
@@ -116,19 +40,22 @@ const ControlButton: React.FC<ControlButtonProps> = ({
   activeIcon,
   isActive = false,
   isDanger = false,
+  disabled = false,
   onClick,
   label,
 }) => {
-  const baseClasses = 'w-12 h-12 rounded-full flex items-center justify-center transition-all';
+  const baseClasses =
+    "w-12 h-12 rounded-full flex items-center justify-center transition-all disabled:opacity-50 disabled:cursor-not-allowed";
   const colorClasses = isDanger
-    ? 'bg-red-500 hover:bg-red-600'
+    ? "bg-red-500 hover:bg-red-600"
     : isActive
-    ? 'bg-gray-600 hover:bg-gray-500'
-    : 'bg-gray-700 hover:bg-gray-600';
+      ? "bg-gray-600 hover:bg-gray-500"
+      : "bg-gray-700 hover:bg-gray-600";
 
   return (
     <button
       onClick={onClick}
+      disabled={disabled}
       className={`${baseClasses} ${colorClasses}`}
       title={label}
     >
@@ -137,199 +64,377 @@ const ControlButton: React.FC<ControlButtonProps> = ({
   );
 };
 
+const VoiceTile: React.FC<{
+  participant: RoomVoiceParticipantState;
+  isCurrentUser: boolean;
+}> = ({ participant, isCurrentUser }) => {
+  const initials = (participant.name || participant.username || "?").slice(0, 1).toUpperCase();
+
+  return (
+    <div className="relative rounded-xl overflow-hidden bg-gray-800 aspect-video shadow-lg">
+      <div className="w-full h-full flex items-center justify-center">
+        <div className="w-16 h-16 rounded-full bg-primary/30 flex items-center justify-center">
+          <span className="text-2xl font-bold text-white">{initials}</span>
+        </div>
+      </div>
+
+      <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-3">
+        <div className="flex items-center justify-between">
+          <div className="text-white">
+            <div className="font-medium">{isCurrentUser ? "You" : participant.username}</div>
+            <div className="text-xs text-white/70">
+              {participant.is_screen_sharing
+                ? "Screen sharing"
+                : participant.is_camera_enabled
+                  ? "Camera on"
+                  : "Voice only"}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            {participant.is_mic_enabled ? (
+              <Mic className="w-4 h-4 text-green-300" />
+            ) : (
+              <MicOff className="w-4 h-4 text-red-400" />
+            )}
+            {participant.is_camera_enabled ? (
+              <Video className="w-4 h-4 text-green-300" />
+            ) : (
+              <VideoOff className="w-4 h-4 text-white/50" />
+            )}
+            {participant.is_screen_sharing && <Monitor className="w-4 h-4 text-blue-300" />}
+          </div>
+        </div>
+      </div>
+
+      {isCurrentUser && (
+        <div className="absolute top-2 right-2 bg-primary rounded px-2 py-0.5">
+          <span className="text-xs font-medium text-white">You</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
 export default function RoomPage(): JSX.Element {
   const { roomID } = useParams();
   const navigate = useNavigate();
   const location = useLocation();
-  const {
-    state: callState,
-    endCall,
-    toggleMic,
-    toggleCamera,
-    toggleScreenShare,
-    initiateCall,
-    livekitClient,
-  } = useCall();
-  const { joinRoom, leaveRoom, isConnected } = useWebSocketContext();
-  const { token } = useAuth();
+  const { token, user } = useAuth();
 
-  // Decode the room name from URL (it's the room name, not ID)
-  const roomName = roomID ? decodeURIComponent(roomID) : '';
-  // Get numeric room ID from navigation state (for calls)
-  const numericRoomId = (location.state as { roomId?: number })?.roomId;
+  const routeRoomName =
+    (location.state as { roomName?: string } | null)?.roomName ??
+    (roomID ? decodeURIComponent(roomID) : "");
+  const roomIdentifier = String(roomID ?? "");
 
-  // Join as member via REST API (required for calls) and WebSocket (for chat)
-  useEffect(() => {
-    if (!roomName || !isConnected) return;
+  const [roomState, setRoomState] = useState<RoomStateResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-    // Join WebSocket room for chat
-    joinRoom(roomName);
+  const loadRoomState = useCallback(async () => {
+    if (!token || !roomIdentifier) return;
 
-    // Also join as member via REST API (required for calls)
-    if (numericRoomId && token) {
-      joinRoomAsMember(String(numericRoomId), token).catch((err) => {
-        console.warn('Failed to join room as member:', err.message);
-      });
+    try {
+      const state = await fetchRoomState(roomIdentifier, token);
+      setRoomState(state);
+      setError(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to fetch room state";
+      setError(message);
+    } finally {
+      setIsLoading(false);
     }
+  }, [roomIdentifier, token]);
 
-    return () => {
-      if (roomName) {
-        leaveRoom(roomName);
+  useEffect(() => {
+    if (!token || !roomIdentifier) return;
+
+    let cancelled = false;
+    const init = async () => {
+      setIsLoading(true);
+      try {
+        await joinRoomAsMember(roomIdentifier, token);
+        if (!cancelled) {
+          await loadRoomState();
+        }
+      } catch (err) {
+        if (!cancelled) {
+          const message = err instanceof Error ? err.message : "Failed to join room";
+          setError(message);
+          setIsLoading(false);
+        }
       }
     };
-  }, [roomName, numericRoomId, token, isConnected, joinRoom, leaveRoom]);
 
-  const handleStartCall = () => {
-    if (numericRoomId && roomName) {
-      initiateCall('room', numericRoomId, roomName);
+    void init();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loadRoomState, roomIdentifier, token]);
+
+  useEffect(() => {
+    if (!token || !roomIdentifier) return;
+
+    const interval = setInterval(() => {
+      void loadRoomState();
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [loadRoomState, roomIdentifier, token]);
+
+  const roomName = roomState?.room.name || routeRoomName;
+  const voiceParticipants = roomState?.voice_participants ?? [];
+  const members = roomState?.members ?? [];
+  const inVoice = roomState?.in_voice ?? false;
+  const myVoiceState = useMemo(
+    () => voiceParticipants.find((participant) => participant.user_id === user?.user_id) ?? null,
+    [voiceParticipants, user?.user_id]
+  );
+
+  const canToggleMedia = inVoice && !isSubmitting;
+
+  const handleJoinVoice = async () => {
+    if (!token || !roomIdentifier) return;
+    setIsSubmitting(true);
+    try {
+      await joinRoomVoice(roomIdentifier, token);
+      await loadRoomState();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to join voice");
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
-  const handleEndCall = () => {
-    endCall();
-  };
-
-  const handleExit = () => {
-    if (callState.status === 'active') {
-      endCall();
+  const handleLeaveVoice = async () => {
+    if (!token || !roomIdentifier) return;
+    setIsSubmitting(true);
+    try {
+      await leaveRoomVoice(roomIdentifier, token);
+      await loadRoomState();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to leave voice");
+    } finally {
+      setIsSubmitting(false);
     }
-    navigate('/home');
   };
 
-  // Get participants for display
-  const participants = livekitClient?.getAllParticipants() || [];
-  const isInCall = callState.status === 'active' || callState.status === 'connecting';
+  const handleUpdateMedia = async (
+    patch: Partial<{
+      is_mic_enabled: boolean;
+      is_camera_enabled: boolean;
+      is_screen_sharing: boolean;
+    }>
+  ) => {
+    if (!token || !roomIdentifier || !inVoice) return;
+    setIsSubmitting(true);
+    try {
+      await updateRoomVoiceMedia(roomIdentifier, patch, token);
+      await loadRoomState();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update media state");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
-  // Calculate grid layout based on participant count
   const getGridClass = () => {
-    const count = participants.length;
-    if (count <= 1) return 'grid-cols-1';
-    if (count === 2) return 'grid-cols-2';
-    if (count <= 4) return 'grid-cols-2';
-    if (count <= 6) return 'grid-cols-3';
-    return 'grid-cols-4';
+    const count = Math.max(voiceParticipants.length, 1);
+    if (count <= 1) return "grid-cols-1";
+    if (count === 2) return "grid-cols-2";
+    if (count <= 4) return "grid-cols-2";
+    if (count <= 6) return "grid-cols-3";
+    return "grid-cols-4";
   };
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col h-screen items-center justify-center bg-gray-50">
+        <div className="w-10 h-10 border-4 border-primary border-t-transparent rounded-full animate-spin mb-4" />
+        <p className="text-gray-600">Loading room...</p>
+      </div>
+    );
+  }
+
+  if (error && !roomState) {
+    return (
+      <div className="flex flex-col h-screen items-center justify-center bg-gray-50 p-4">
+        <div className="text-center max-w-md">
+          <h2 className="text-xl font-semibold text-red-600 mb-2">Room Error</h2>
+          <p className="text-gray-600 mb-4">{error}</p>
+          <button
+            onClick={() => navigate(-1)}
+            className="px-4 py-2 rounded bg-primary text-white"
+          >
+            Go Back
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col h-screen bg-gray-900">
-      {/* Header */}
       <header className="flex items-center justify-between px-4 py-3 bg-gray-800 border-b border-gray-700">
         <div className="flex items-center gap-3">
           <button
-            onClick={handleExit}
+            onClick={() => navigate(-1)}
             className="p-2 rounded-lg hover:bg-gray-700 transition-colors"
           >
             <ArrowLeft className="w-5 h-5 text-white" />
           </button>
-          <h1 className="text-lg font-semibold text-white">Room: {roomName}</h1>
+          <div>
+            <h1 className="text-lg font-semibold text-white">Room: {roomName}</h1>
+            <p className="text-sm text-white/70">
+              {members.length} members, {voiceParticipants.length} in voice
+            </p>
+          </div>
         </div>
 
-        <div className="flex items-center gap-4">
-          {isInCall && (
-            <div className="flex items-center gap-2 text-white/80">
-              <Users className="w-4 h-4" />
-              <span className="text-sm">{participants.length}</span>
-            </div>
-          )}
-          {!isInCall && numericRoomId && (
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2 text-white/80">
+            <Users className="w-4 h-4" />
+            <span className="text-sm">{members.length}</span>
+          </div>
+          {inVoice ? (
             <button
-              onClick={handleStartCall}
-              className="flex items-center gap-2 px-4 py-2 bg-green-500 hover:bg-green-600 rounded-lg transition-colors"
+              onClick={handleLeaveVoice}
+              disabled={isSubmitting}
+              className="flex items-center gap-2 px-4 py-2 bg-red-500 hover:bg-red-600 rounded-lg transition-colors disabled:opacity-50"
             >
-              <Video className="w-4 h-4 text-white" />
-              <span className="text-white text-sm font-medium">Start Call</span>
+              <PhoneOff className="w-4 h-4 text-white" />
+              <span className="text-white text-sm font-medium">Leave Voice</span>
+            </button>
+          ) : (
+            <button
+              onClick={handleJoinVoice}
+              disabled={isSubmitting}
+              className="flex items-center gap-2 px-4 py-2 bg-green-500 hover:bg-green-600 rounded-lg transition-colors disabled:opacity-50"
+            >
+              <Radio className="w-4 h-4 text-white" />
+              <span className="text-white text-sm font-medium">Join Voice</span>
             </button>
           )}
         </div>
       </header>
 
-      {/* Main content */}
       <main className="flex-1 overflow-hidden">
-        {isInCall ? (
-          // Active call view
-          <div className="h-full flex flex-col">
-            {/* Video grid */}
-            <div className="flex-1 p-4 overflow-auto">
-              {callState.status === 'connecting' ? (
-                <div className="h-full flex items-center justify-center">
-                  <div className="text-center">
-                    <div className="w-12 h-12 border-4 border-primary border-t-transparent rounded-full animate-spin mx-auto mb-4" />
-                    <p className="text-white text-lg">Connecting...</p>
+        <div className="h-full flex flex-col">
+          <div className="flex-1 p-4 overflow-auto">
+            {voiceParticipants.length === 0 ? (
+              <div className="h-full flex items-center justify-center">
+                <div className="text-center max-w-md p-8">
+                  <div className="w-20 h-20 rounded-full bg-gray-800 flex items-center justify-center mx-auto mb-6">
+                    <Radio className="w-10 h-10 text-gray-500" />
                   </div>
+                  <h2 className="text-xl font-semibold text-white mb-2">Voice channel is empty</h2>
+                  <p className="text-gray-400 mb-6">
+                    Join the room voice channel to start talking, turn on camera, or share your screen.
+                  </p>
+                  {!inVoice && (
+                    <button
+                      onClick={handleJoinVoice}
+                      disabled={isSubmitting}
+                      className="flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-hover rounded-lg transition-colors mx-auto disabled:opacity-50"
+                    >
+                      <Radio className="w-5 h-5 text-white" />
+                      <span className="text-white font-medium">Join Voice</span>
+                    </button>
+                  )}
                 </div>
-              ) : (
-                <div className={`grid ${getGridClass()} gap-4 h-full`}>
-                  {participants.map((p) => (
-                    <VideoTile key={p.sid} participant={p} />
-                  ))}
-                </div>
-              )}
-            </div>
-
-            {/* Call controls */}
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              className="flex items-center justify-center gap-4 p-4 bg-gray-800 border-t border-gray-700"
-            >
-              <ControlButton
-                icon={<Mic className="w-5 h-5 text-white" />}
-                activeIcon={<MicOff className="w-5 h-5 text-red-400" />}
-                isActive={callState.localMuted}
-                onClick={toggleMic}
-                label={callState.localMuted ? 'Unmute' : 'Mute'}
-              />
-
-              <ControlButton
-                icon={<Video className="w-5 h-5 text-white" />}
-                activeIcon={<VideoOff className="w-5 h-5 text-red-400" />}
-                isActive={callState.localCameraOff}
-                onClick={toggleCamera}
-                label={callState.localCameraOff ? 'Turn on camera' : 'Turn off camera'}
-              />
-
-              <ControlButton
-                icon={<Monitor className="w-5 h-5 text-white" />}
-                isActive={callState.screenSharing}
-                onClick={toggleScreenShare}
-                label={callState.screenSharing ? 'Stop sharing' : 'Share screen'}
-              />
-
-              <ControlButton
-                icon={<PhoneOff className="w-5 h-5 text-white" />}
-                isDanger
-                onClick={handleEndCall}
-                label="Leave call"
-              />
-            </motion.div>
-          </div>
-        ) : (
-          // No active call - show placeholder
-          <div className="h-full flex items-center justify-center">
-            <div className="text-center max-w-md p-8">
-              <div className="w-20 h-20 rounded-full bg-gray-800 flex items-center justify-center mx-auto mb-6">
-                <Video className="w-10 h-10 text-gray-500" />
               </div>
-              <h2 className="text-xl font-semibold text-white mb-2">
-                No active call
-              </h2>
-              <p className="text-gray-400 mb-6">
-                Start a video call to connect with others in this room
-              </p>
-              {numericRoomId ? (
-                <button
-                  onClick={handleStartCall}
-                  className="flex items-center gap-2 px-6 py-3 bg-primary hover:bg-primary-hover rounded-lg transition-colors mx-auto"
-                >
-                  <Video className="w-5 h-5 text-white" />
-                  <span className="text-white font-medium">Start Video Call</span>
-                </button>
-              ) : (
-                <p className="text-gray-500 text-sm">Video calls not available (missing room data)</p>
-              )}
-            </div>
+            ) : (
+              <div className={`grid ${getGridClass()} gap-4 h-full`}>
+                {voiceParticipants.map((participant) => (
+                  <VoiceTile
+                    key={participant.user_id}
+                    participant={participant}
+                    isCurrentUser={participant.user_id === user?.user_id}
+                  />
+                ))}
+              </div>
+            )}
           </div>
-        )}
+
+          <section className="px-4 py-3 bg-gray-850 border-t border-gray-700">
+            <h2 className="text-sm font-semibold text-white/80 mb-2">Room Members</h2>
+            <div className="flex flex-wrap gap-2">
+              {members.map((member) => {
+                const isInVoice = voiceParticipants.some(
+                  (participant) => participant.user_id === member.user_id
+                );
+                return (
+                  <div
+                    key={member.user_id}
+                    className={`px-3 py-2 rounded-lg text-sm ${
+                      isInVoice ? "bg-blue-500/20 text-blue-200" : "bg-gray-800 text-white/75"
+                    }`}
+                  >
+                    {member.username}
+                    {member.user_id === user?.user_id ? " (you)" : ""}
+                    {isInVoice ? " • in voice" : ""}
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="flex items-center justify-center gap-4 p-4 bg-gray-800 border-t border-gray-700"
+          >
+            <ControlButton
+              icon={<Mic className="w-5 h-5 text-white" />}
+              activeIcon={<MicOff className="w-5 h-5 text-red-400" />}
+              isActive={!myVoiceState?.is_mic_enabled}
+              disabled={!canToggleMedia}
+              onClick={() =>
+                void handleUpdateMedia({ is_mic_enabled: !myVoiceState?.is_mic_enabled })
+              }
+              label={myVoiceState?.is_mic_enabled ? "Mute" : "Unmute"}
+            />
+
+            <ControlButton
+              icon={<Video className="w-5 h-5 text-white" />}
+              activeIcon={<VideoOff className="w-5 h-5 text-red-400" />}
+              isActive={!myVoiceState?.is_camera_enabled}
+              disabled={!canToggleMedia}
+              onClick={() =>
+                void handleUpdateMedia({ is_camera_enabled: !myVoiceState?.is_camera_enabled })
+              }
+              label={myVoiceState?.is_camera_enabled ? "Turn off camera" : "Turn on camera"}
+            />
+
+            <ControlButton
+              icon={<Monitor className="w-5 h-5 text-white" />}
+              activeIcon={<MonitorOff className="w-5 h-5 text-red-400" />}
+              isActive={Boolean(myVoiceState?.is_screen_sharing)}
+              disabled={!canToggleMedia}
+              onClick={() =>
+                void handleUpdateMedia({
+                  is_screen_sharing: !myVoiceState?.is_screen_sharing,
+                })
+              }
+              label={myVoiceState?.is_screen_sharing ? "Stop sharing" : "Share screen"}
+            />
+
+            <ControlButton
+              icon={<PhoneOff className="w-5 h-5 text-white" />}
+              isDanger
+              disabled={!inVoice || isSubmitting}
+              onClick={() => void handleLeaveVoice()}
+              label="Leave voice"
+            />
+          </motion.div>
+
+          {error && (
+            <div className="px-4 py-2 bg-red-500/10 border-t border-red-400/30 text-red-200 text-sm">
+              {error}
+            </div>
+          )}
+        </div>
       </main>
     </div>
   );

--- a/src/pages/RoomPage.tsx
+++ b/src/pages/RoomPage.tsx
@@ -29,6 +29,7 @@ interface ControlButtonProps {
   activeIcon?: React.ReactNode;
   isActive?: boolean;
   isDanger?: boolean;
+  isPressed?: boolean;
   disabled?: boolean;
   onClick: () => void;
   label: string;
@@ -39,6 +40,7 @@ const ControlButton: React.FC<ControlButtonProps> = ({
   activeIcon,
   isActive = false,
   isDanger = false,
+  isPressed,
   disabled = false,
   onClick,
   label,
@@ -57,6 +59,9 @@ const ControlButton: React.FC<ControlButtonProps> = ({
       disabled={disabled}
       className={`${baseClasses} ${colorClasses}`}
       title={label}
+      aria-label={label}
+      aria-pressed={isDanger ? undefined : isPressed}
+      aria-disabled={disabled}
     >
       {isActive && activeIcon ? activeIcon : icon}
     </button>
@@ -603,6 +608,7 @@ export default function RoomPage(): JSX.Element {
               icon={<MicOff className="w-5 h-5 text-red-400" />}
               activeIcon={<Mic className="w-5 h-5 text-white" />}
               isActive={isCurrentRoomSession ? roomVoiceState.localMuted : !myVoiceState?.is_mic_enabled}
+              isPressed={Boolean(isCurrentRoomSession ? !roomVoiceState.localMuted : myVoiceState?.is_mic_enabled)}
               disabled={!canToggleMedia}
               onClick={() => void handleToggleMic()}
               label={isCurrentRoomSession && roomVoiceState.localMuted ? "Unmute" : "Mute"}
@@ -612,6 +618,7 @@ export default function RoomPage(): JSX.Element {
               icon={<VideoOff className="w-5 h-5 text-red-400" />}
               activeIcon={<Video className="w-5 h-5 text-white" />}
               isActive={isCurrentRoomSession ? roomVoiceState.localCameraOff : !myVoiceState?.is_camera_enabled}
+              isPressed={Boolean(isCurrentRoomSession ? !roomVoiceState.localCameraOff : myVoiceState?.is_camera_enabled)}
               disabled={!canToggleMedia}
               onClick={() => void handleToggleCamera()}
               label={
@@ -625,6 +632,7 @@ export default function RoomPage(): JSX.Element {
               icon={<MonitorOff className="w-5 h-5 text-red-400" />}
               activeIcon={<Monitor className="w-5 h-5 text-white" />}
               isActive={!(isCurrentRoomSession ? roomVoiceState.screenSharing : Boolean(myVoiceState?.is_screen_sharing))}
+              isPressed={Boolean(isCurrentRoomSession ? roomVoiceState.screenSharing : myVoiceState?.is_screen_sharing)}
               disabled={!canToggleMedia}
               onClick={() => void handleToggleScreenShare()}
               label={

--- a/src/pages/RoomsPage.tsx
+++ b/src/pages/RoomsPage.tsx
@@ -266,11 +266,11 @@ const RoomsPage: React.FC = () => {
                     key={friend.user_id}
                     className="flex justify-between items-center p-2 hover:bg-gray-100 rounded"
                   >
-                    <span>{friend.user_id}</span>
+                    <span>{friend.username}</span>
                     <Button
                       variant="primary"
                       size="sm"
-                      onClick={() => handleConfirmInvite(friend.user_id)}
+                      onClick={() => handleConfirmInvite(friend.username)}
                     >
                       Пригласить
                     </Button>

--- a/src/pages/RoomsPage.tsx
+++ b/src/pages/RoomsPage.tsx
@@ -125,11 +125,9 @@ const RoomsPage: React.FC = () => {
   };
 
   // Функция присоединения к комнате (навигация к RoomPage)
-  // Use room name in URL since WebSocket protocol uses names, not IDs
-  // Pass room_id in state for call functionality
   const handleJoinRoom = (room: Room) => {
-    navigate(`/room/${encodeURIComponent(room.name)}`, {
-      state: { roomId: parseInt(room.room_id, 10) }
+    navigate(`/room/${encodeURIComponent(room.room_id)}`, {
+      state: { roomName: room.name }
     });
   };
 

--- a/src/pages/RoomsPage.tsx
+++ b/src/pages/RoomsPage.tsx
@@ -15,7 +15,7 @@ import { useNavigate } from "react-router-dom";
 import { Room, Friend } from "../types";
 
 const RoomsPage: React.FC = () => {
-  const { token } = useAuth();
+  const { token, user } = useAuth();
   const navigate = useNavigate();
   // Состояния для комнат, приглашённых комнат, списка друзей
   const [rooms, setRooms] = useState<Room[]>([]);
@@ -41,7 +41,10 @@ const RoomsPage: React.FC = () => {
         const fetchedFriends = await fetchFriends(token);
 
         // Отмечаем комнаты: свои — is_owner = true, приглашённые — false
-        const markedOwnRooms = ownRooms.map((room) => ({ ...room, is_owner: true }));
+        const markedOwnRooms = ownRooms.map((room) => ({
+          ...room,
+          is_owner: room.user_id === user?.user_id,
+        }));
         const markedInvitedRooms = invited.map((room) => ({ ...room, is_owner: false }));
 
         setRooms(markedOwnRooms);
@@ -52,10 +55,12 @@ const RoomsPage: React.FC = () => {
       }
     };
     loadData();
-  }, [token]);
+  }, [token, user?.user_id]);
 
   // Объединяем списки комнат
   const allRooms: Room[] = [...rooms, ...invitedRooms];
+  const getRoomDisplayName = (room: Room) =>
+    room.name.startsWith("__direct__:") ? "Private voice room" : room.name;
 
   // Функция создания новой комнаты
   const handleCreateRoom = async () => {
@@ -189,7 +194,7 @@ const RoomsPage: React.FC = () => {
               }`}
             >
               <div className="mb-2">
-                <h3 className="font-medium">{room.name}</h3>
+                <h3 className="font-medium">{getRoomDisplayName(room)}</h3>
               </div>
               <div className="flex justify-between items-center">
                 <Button

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -63,7 +63,7 @@ export async function validateToken(token: string): Promise<boolean> {
   
 export async function login(username: string, password: string): Promise<string> {
   try {
-    const response = await fetch(`${API_BASE_URL}/login`, {
+    const response = await fetch(`${API_BASE_URL}/auth/login`, {
       method: "POST",
       headers: headers(),
       body: JSON.stringify({ username, password }),
@@ -83,7 +83,7 @@ export async function login(username: string, password: string): Promise<string>
 
 export async function register(username: string, password: string): Promise<string> {
   try {
-    const response = await fetch(`${API_BASE_URL}/register`, {
+    const response = await fetch(`${API_BASE_URL}/auth/register`, {
       method: "POST",
       headers: headers(),
       body: JSON.stringify({ username, password }),
@@ -112,18 +112,60 @@ export async function getUserID(token: string): Promise<string> {
 // Backward-compatible fallback for legacy UI code.
 // Current backend has no public GET /api/user/:id endpoint.
 export async function getUserInfo(token: string, uuid: string): Promise<UserInfo> {
-  void token;
+  const response = await fetch(`${API_BASE_URL}/user/${uuid}`, {
+    method: "GET",
+    headers: headers(token),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || "Failed to fetch user info");
+  }
+
+  const payload = (await response.json()) as {
+    user?:
+      | UserInfo
+      | {
+          ID?: number;
+          Username?: string;
+          Name?: string;
+          id?: number;
+          username?: string;
+          name?: string;
+        };
+  };
+
+  const user = payload.user;
+  if (!user) {
+    throw new Error("User info is missing in response");
+  }
+
+  const legacyUser = user as {
+    ID?: number;
+    Username?: string;
+    Name?: string;
+    id?: number;
+    username?: string;
+    name?: string;
+  };
+
   return {
-    id: Number(uuid) || 0,
-    username: `user-${uuid}`,
-    name: `user-${uuid}`,
+    id: typeof legacyUser.id === "number" ? legacyUser.id : (legacyUser.ID ?? 0),
+    username: legacyUser.username ?? legacyUser.Username ?? `user-${uuid}`,
+    name: legacyUser.name ?? legacyUser.Name ?? `user-${uuid}`,
   };
 }
 
 export async function getMe(token: string): Promise<User> {
-  const user = decodeJWT(token);
-  if (!user) {
-    throw new Error("Invalid token");
+  const response = await fetch(`${API_BASE_URL}/user/me`, {
+    method: "GET",
+    headers: headers(token),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || "Failed to fetch current user");
   }
-  return user;
+
+  return response.json();
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -31,6 +31,88 @@ export const headers = (token?: string) => ({
     "X-Client-Type": "desktop",
   });
 
+const toNumber = (value: unknown): number => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return 0;
+};
+
+const normalizeUserPayload = (payload: unknown): User => {
+  const root =
+    payload && typeof payload === "object" && "user" in payload
+      ? (payload as { user?: unknown }).user
+      : payload;
+
+  if (!root || typeof root !== "object") {
+    throw new Error("Current user payload is missing");
+  }
+
+  const candidate = root as Record<string, unknown>;
+  const username =
+    typeof candidate.username === "string"
+      ? candidate.username
+      : typeof candidate.Username === "string"
+        ? candidate.Username
+        : typeof candidate.user_name === "string"
+          ? candidate.user_name
+          : typeof candidate.UserName === "string"
+            ? candidate.UserName
+            : "";
+  const userID =
+    typeof candidate.user_id === "string"
+      ? candidate.user_id
+      : typeof candidate.UserID === "string"
+        ? candidate.UserID
+        : "";
+
+  if (!username || !userID) {
+    throw new Error("Current user payload is invalid");
+  }
+
+  const id = toNumber(candidate.id ?? candidate.ID);
+  const name =
+    typeof candidate.name === "string"
+      ? candidate.name
+      : typeof candidate.Name === "string"
+        ? candidate.Name
+        : username;
+  const email =
+    typeof candidate.email === "string"
+      ? candidate.email
+      : typeof candidate.Email === "string"
+        ? candidate.Email
+        : "";
+  const isOnline =
+    typeof candidate.is_online === "boolean"
+      ? candidate.is_online
+      : typeof candidate.IsOnline === "boolean"
+        ? candidate.IsOnline
+        : true;
+  const createdAt =
+    typeof candidate.created_at === "string"
+      ? candidate.created_at
+      : typeof candidate.CreatedAt === "string"
+        ? candidate.CreatedAt
+        : new Date().toISOString();
+
+  return {
+    id,
+    user_id: userID,
+    username,
+    name,
+    email,
+    is_online: isOnline,
+    created_at: createdAt,
+  };
+};
+
 // checkAPIStatus verifies that the backend healthcheck endpoint responds.
 export async function checkAPIStatus(): Promise<boolean> {
   try {
@@ -190,5 +272,5 @@ export async function getMe(token: string): Promise<User> {
     throw new Error(errorData.error || "Failed to fetch current user");
   }
 
-  return response.json();
+  return normalizeUserPayload(await response.json());
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -31,6 +31,7 @@ export const headers = (token?: string) => ({
     "X-Client-Type": "desktop",
   });
 
+// checkAPIStatus verifies that the backend healthcheck endpoint responds.
 export async function checkAPIStatus(): Promise<boolean> {
   try {
     const response = await fetch(`${API_BASE_URL}/ping`, { method: "GET" });
@@ -42,6 +43,7 @@ export async function checkAPIStatus(): Promise<boolean> {
   }
 }
 
+// validateToken confirms token freshness locally and against the backend profile endpoint.
 export async function validateToken(token: string): Promise<boolean> {
   try {
     const user = decodeJWT(token);
@@ -67,6 +69,7 @@ export async function validateToken(token: string): Promise<boolean> {
   }
 }
   
+// login authenticates a user and returns the issued JWT.
 export async function login(username: string, password: string): Promise<string> {
   try {
     const response = await fetch(`${API_BASE_URL}/auth/login`, {
@@ -87,6 +90,7 @@ export async function login(username: string, password: string): Promise<string>
   }
 }
 
+// register creates a new user account and returns the server response token if present.
 export async function register(username: string, password: string): Promise<string> {
   try {
     const response = await fetch(`${API_BASE_URL}/auth/register`, {
@@ -107,6 +111,7 @@ export async function register(username: string, password: string): Promise<stri
   }
 }
 
+// getUserID fetches the authenticated user's UUID from the backend.
 export async function getUserID(token: string): Promise<string> {
   const response = await fetch(`${API_BASE_URL}/user/id`, {
     method: "GET",
@@ -173,6 +178,7 @@ export async function getUserInfo(token: string, uuid: string): Promise<UserInfo
   };
 }
 
+// getMe fetches the authenticated user's current profile from the backend.
 export async function getMe(token: string): Promise<User> {
   const response = await fetch(`${API_BASE_URL}/user/me`, {
     method: "GET",

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -4,16 +4,19 @@ import { API_BASE_URL } from "./config";
 // Decode JWT token to extract user info (no server call needed)
 export function decodeJWT(token: string): User | null {
   try {
-    const base64Url = token.split('.')[1];
-    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    const base64Url = token.split(".")[1];
+    if (!base64Url) {
+      return null;
+    }
+    const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
     const payload = JSON.parse(atob(base64));
 
     return {
       id: payload.user_id,
       user_id: String(payload.user_id),
-      username: payload.username,
-      name: payload.username,
-      email: '',
+      username: payload.username ?? "",
+      name: payload.name ?? payload.username ?? "",
+      email: "",
       is_online: true,
       created_at: new Date().toISOString(),
     };
@@ -105,11 +108,22 @@ export async function register(username: string, password: string): Promise<stri
 }
 
 export async function getUserID(token: string): Promise<string> {
-  const user = decodeJWT(token);
-  if (!user) {
-    throw new Error("Invalid token");
+  const response = await fetch(`${API_BASE_URL}/user/id`, {
+    method: "GET",
+    headers: headers(token),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || "Failed to fetch current user ID");
   }
-  return String(user.id);
+
+  const payload = (await response.json()) as { userID?: string };
+  if (!payload.userID) {
+    throw new Error("Current user ID is missing in response");
+  }
+
+  return payload.userID;
 }
 
 // Backward-compatible fallback for legacy UI code.

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -41,20 +41,23 @@ export async function checkAPIStatus(): Promise<boolean> {
 
 export async function validateToken(token: string): Promise<boolean> {
   try {
-    // Decode JWT locally - no server call needed
     const user = decodeJWT(token);
     if (!user) return false;
 
-    // Check expiration (JWT exp claim is in seconds)
     const base64Url = token.split('.')[1];
     const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
     const payload = JSON.parse(atob(base64));
 
     if (payload.exp && payload.exp * 1000 < Date.now()) {
-      return false; // Token expired
+      return false;
     }
 
-    return true;
+    const response = await fetch(`${API_BASE_URL}/user/me`, {
+      method: "GET",
+      headers: headers(token),
+    });
+
+    return response.ok;
   } catch (error) {
     console.error("Token validation error:", error);
     return false;

--- a/src/services/chat-api.ts
+++ b/src/services/chat-api.ts
@@ -1,5 +1,6 @@
 import { IChatMessageResponse } from "../types";
 import { API_BASE_URL, WS_BASE_URL } from "./config";
+import { headers } from "./api";
 
 export async function fetchDirectChatHistory(
   token: string,
@@ -12,6 +13,7 @@ export async function fetchDirectChatHistory(
 
   const response = await fetch(`${API_BASE_URL}/chat/history?${query.toString()}`, {
     method: "GET",
+    headers: headers(token),
   });
 
   if (!response.ok) {

--- a/src/services/chat-api.ts
+++ b/src/services/chat-api.ts
@@ -7,7 +7,6 @@ export async function fetchDirectChatHistory(
   withUserID: string
 ): Promise<IChatMessageResponse[]> {
   const query = new URLSearchParams({
-    token,
     with_user: withUserID,
   });
 

--- a/src/services/chat-api.ts
+++ b/src/services/chat-api.ts
@@ -1,11 +1,65 @@
-import { headers } from "./api";
-import { API_BASE_URL } from "./config";
 import { IChatMessageResponse } from "../types";
+import { API_BASE_URL, WS_BASE_URL } from "./config";
 
-export async function fetchChatHistory(token: string): Promise<IChatMessageResponse[]> {
-    // Legacy endpoint is not available on current backend.
-    // Keep function for compatibility with older UI paths.
-    void API_BASE_URL;
-    void headers(token);
-    return [];
+export async function fetchDirectChatHistory(
+  token: string,
+  withUserID: string
+): Promise<IChatMessageResponse[]> {
+  const query = new URLSearchParams({
+    token,
+    with_user: withUserID,
+  });
+
+  const response = await fetch(`${API_BASE_URL}/chat/history?${query.toString()}`, {
+    method: "GET",
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || "Failed to fetch chat history");
+  }
+
+  const payload = (await response.json()) as { messages?: IChatMessageResponse[] };
+  return payload.messages ?? [];
+}
+
+export interface DirectChatSocketHandlers {
+  onOpen?: () => void;
+  onClose?: () => void;
+  onError?: () => void;
+  onMessage?: (message: { from: string; to: string; message: string }) => void;
+}
+
+export function connectDirectChatSocket(
+  token: string,
+  handlers: DirectChatSocketHandlers
+): WebSocket {
+  const ws = new WebSocket(`${WS_BASE_URL}?token=${encodeURIComponent(token)}`);
+
+  ws.addEventListener("open", () => handlers.onOpen?.());
+  ws.addEventListener("close", () => handlers.onClose?.());
+  ws.addEventListener("error", () => handlers.onError?.());
+  ws.addEventListener("message", (event) => {
+    try {
+      const payload = JSON.parse(event.data) as {
+        from?: string;
+        to?: string;
+        message?: string;
+      };
+
+      if (!payload.from || !payload.to || typeof payload.message !== "string") {
+        return;
+      }
+
+      handlers.onMessage?.({
+        from: payload.from,
+        to: payload.to,
+        message: payload.message,
+      });
+    } catch {
+      // Ignore malformed frames from unrelated protocols.
+    }
+  });
+
+  return ws;
 }

--- a/src/services/chat-api.ts
+++ b/src/services/chat-api.ts
@@ -21,8 +21,10 @@ export async function fetchDirectChatHistory(
     throw new Error(errorData.error || "Failed to fetch chat history");
   }
 
-  const payload = (await response.json()) as { messages?: IChatMessageResponse[] };
-  return payload.messages ?? [];
+  const payload = (await response.json()) as { messages?: unknown };
+  return Array.isArray(payload.messages)
+    ? (payload.messages as IChatMessageResponse[])
+    : [];
 }
 
 // DirectChatSocketHandlers contains callbacks for direct chat websocket lifecycle events.
@@ -51,7 +53,11 @@ export function connectDirectChatSocket(
         message?: string;
       };
 
-      if (!payload.from || !payload.to || typeof payload.message !== "string") {
+      if (
+        typeof payload.from !== "string" ||
+        typeof payload.to !== "string" ||
+        typeof payload.message !== "string"
+      ) {
         return;
       }
 

--- a/src/services/chat-api.ts
+++ b/src/services/chat-api.ts
@@ -2,6 +2,7 @@ import { IChatMessageResponse } from "../types";
 import { API_BASE_URL, WS_BASE_URL } from "./config";
 import { headers } from "./api";
 
+// fetchDirectChatHistory returns the ordered direct-message history with another user.
 export async function fetchDirectChatHistory(
   token: string,
   withUserID: string
@@ -24,6 +25,7 @@ export async function fetchDirectChatHistory(
   return payload.messages ?? [];
 }
 
+// DirectChatSocketHandlers contains callbacks for direct chat websocket lifecycle events.
 export interface DirectChatSocketHandlers {
   onOpen?: () => void;
   onClose?: () => void;
@@ -31,6 +33,7 @@ export interface DirectChatSocketHandlers {
   onMessage?: (message: { from: string; to: string; message: string }) => void;
 }
 
+// connectDirectChatSocket opens a direct chat websocket and wires the provided callbacks.
 export function connectDirectChatSocket(
   token: string,
   handlers: DirectChatSocketHandlers

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -30,12 +30,14 @@ const getDefaultWsBaseUrl = (): string => {
   return `${wsProtocol}//${host}/api/chat/ws`;
 };
 
+// API_BASE_URL is the resolved base URL for HTTP API requests.
 export const API_BASE_URL = trimTrailingSlashes(
   envApiBaseUrl && envApiBaseUrl.length > 0
     ? envApiBaseUrl
     : getDefaultApiBaseUrl()
 );
 
+// WS_BASE_URL is the resolved base URL for chat websocket connections.
 export const WS_BASE_URL = trimTrailingSlashes(
   envWsUrl && envWsUrl.length > 0 ? envWsUrl : getDefaultWsBaseUrl()
 );

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -8,8 +8,16 @@ const getDefaultApiBaseUrl = (): string => {
     return "http://localhost:8080/api";
   }
 
-  const { origin, port } = window.location;
+  const { origin, port, protocol, hostname } = window.location;
   if (port === "1420") {
+    return "http://localhost:8080/api";
+  }
+
+  if (protocol === "tauri:" || protocol === "file:") {
+    return "http://localhost:8080/api";
+  }
+
+  if (hostname === "localhost" || hostname === "127.0.0.1") {
     return "http://localhost:8080/api";
   }
 
@@ -21,8 +29,16 @@ const getDefaultWsBaseUrl = (): string => {
     return "ws://localhost:8080/api/chat/ws";
   }
 
-  const { host, port, protocol } = window.location;
+  const { host, port, protocol, hostname } = window.location;
   if (port === "1420") {
+    return "ws://localhost:8080/api/chat/ws";
+  }
+
+  if (protocol === "tauri:" || protocol === "file:") {
+    return "ws://localhost:8080/api/chat/ws";
+  }
+
+  if (hostname === "localhost" || hostname === "127.0.0.1") {
     return "ws://localhost:8080/api/chat/ws";
   }
 

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -3,13 +3,39 @@ const trimTrailingSlashes = (value: string): string => value.replace(/\/+$/, "")
 const envApiBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim();
 const envWsUrl = import.meta.env.VITE_WS_URL?.trim();
 
-// Defaults keep local desktop/dev behavior unchanged.
+const getDefaultApiBaseUrl = (): string => {
+  if (typeof window === "undefined") {
+    return "http://localhost:8080/api";
+  }
+
+  const { origin, port } = window.location;
+  if (port === "1420") {
+    return "http://localhost:8080/api";
+  }
+
+  return `${origin}/api`;
+};
+
+const getDefaultWsBaseUrl = (): string => {
+  if (typeof window === "undefined") {
+    return "ws://localhost:8080/api/chat/ws";
+  }
+
+  const { host, port, protocol } = window.location;
+  if (port === "1420") {
+    return "ws://localhost:8080/api/chat/ws";
+  }
+
+  const wsProtocol = protocol === "https:" ? "wss:" : "ws:";
+  return `${wsProtocol}//${host}/api/chat/ws`;
+};
+
 export const API_BASE_URL = trimTrailingSlashes(
   envApiBaseUrl && envApiBaseUrl.length > 0
     ? envApiBaseUrl
-    : "http://localhost:8080/api"
+    : getDefaultApiBaseUrl()
 );
 
 export const WS_BASE_URL = trimTrailingSlashes(
-  envWsUrl && envWsUrl.length > 0 ? envWsUrl : "ws://localhost:8080/ws"
+  envWsUrl && envWsUrl.length > 0 ? envWsUrl : getDefaultWsBaseUrl()
 );

--- a/src/services/conversations-api.ts
+++ b/src/services/conversations-api.ts
@@ -2,6 +2,7 @@ import { ConversationInfo } from "../types";
 import { headers } from "./api";
 import { API_BASE_URL } from "./config";
 
+// fetchConversations returns the user's existing direct-message conversation previews.
 export async function fetchConversations(token: string): Promise<ConversationInfo[]> {
   const response = await fetch(`${API_BASE_URL}/chat/conversations`, {
     method: "GET",

--- a/src/services/conversations-api.ts
+++ b/src/services/conversations-api.ts
@@ -1,0 +1,18 @@
+import { ConversationInfo } from "../types";
+import { headers } from "./api";
+import { API_BASE_URL } from "./config";
+
+export async function fetchConversations(token: string): Promise<ConversationInfo[]> {
+  const response = await fetch(`${API_BASE_URL}/chat/conversations`, {
+    method: "GET",
+    headers: headers(token),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || "Failed to fetch conversations");
+  }
+
+  const payload = (await response.json()) as { conversations?: ConversationInfo[] };
+  return payload.conversations ?? [];
+}

--- a/src/services/friends-api.ts
+++ b/src/services/friends-api.ts
@@ -19,6 +19,7 @@ interface FriendRequestResponse {
   created_at: string;
 }
 
+// fetchFriendRequests returns pending incoming friend requests for the current user.
 export async function fetchFriendRequests(token: string): Promise<FriendRequest[]> {
   const response = await fetch(`${API_BASE_URL}/friends/requests`, {
     method: "GET",
@@ -58,6 +59,7 @@ export async function fetchFriendRequests(token: string): Promise<FriendRequest[
   }));
 }
 
+// acceptFriendRequest accepts a pending friend request by numeric request ID.
 export async function acceptFriendRequest(requestId: number, token: string): Promise<void> {
   const response = await fetch(`${API_BASE_URL}/friends/accept`, {
     method: "POST",
@@ -70,6 +72,7 @@ export async function acceptFriendRequest(requestId: number, token: string): Pro
   }
 }
 
+// declineFriendRequest declines a pending friend request by numeric request ID.
 export async function declineFriendRequest(requestId: number, token: string): Promise<void> {
   const response = await fetch(`${API_BASE_URL}/friends/decline`, {
     method: "POST",
@@ -82,6 +85,7 @@ export async function declineFriendRequest(requestId: number, token: string): Pr
   }
 }
 
+// requestFriend sends a friend request to another user by username.
 export async function requestFriend(friendUsername: string, token: string): Promise<void> {
   const response = await fetch(`${API_BASE_URL}/friends/request`, {
     method: "POST",
@@ -94,6 +98,7 @@ export async function requestFriend(friendUsername: string, token: string): Prom
   }
 }
 
+// fetchFriends returns the current user's accepted friends.
 export async function fetchFriends(token: string): Promise<Friend[]> {
   const response = await fetch(`${API_BASE_URL}/friends`, {
     method: "GET",
@@ -117,10 +122,12 @@ export async function fetchFriends(token: string): Promise<Friend[]> {
   }));
 }
 
+// addFriend creates a friendship directly when the backend supports immediate add flow.
 export async function addFriend(friendUsername: string, token: string): Promise<void> {
   return requestFriend(friendUsername, token);
 }
 
+// removeFriend deletes a friendship by target username.
 export async function removeFriend(friendUsername: string, token: string): Promise<void> {
   const response = await fetch(`${API_BASE_URL}/friends/remove`, {
     method: "DELETE",
@@ -133,6 +140,7 @@ export async function removeFriend(friendUsername: string, token: string): Promi
   }
 }
 
+// searchUsers finds candidate users for the friends UI search flow.
 export async function searchUsers(query: string, token: string, signal?: AbortSignal): Promise<User[]> {
   const response = await fetch(`${API_BASE_URL}/friends/search?q=${encodeURIComponent(query)}`, {
     method: "GET",
@@ -158,18 +166,21 @@ export async function searchUsers(query: string, token: string, signal?: AbortSi
   }));
 }
 
+// pinFriend marks a friend as pinned in the sidebar.
 export async function pinFriend(friendId: number, token: string): Promise<void> {
   void friendId;
   void token;
   throw new Error("Pin friend is not implemented on this server");
 }
 
+// unpinFriend removes the pinned flag from a friend.
 export async function unpinFriend(friendId: number, token: string): Promise<void> {
   void friendId;
   void token;
   throw new Error("Unpin friend is not implemented on this server");
 }
 
+// fetchPinnedFriends returns pinned friends or an empty list when unsupported.
 export async function fetchPinnedFriends(_token: string): Promise<Friend[]> {
   return [];
 }

--- a/src/services/friends-api.ts
+++ b/src/services/friends-api.ts
@@ -1,24 +1,26 @@
 import { FriendRequest, Friend, User } from "../types";
-import { decodeJWT, headers } from "./api";
+import { decodeJWT, getUserInfo, headers } from "./api";
 import { API_BASE_URL } from "./config";
 
 interface FriendResponse {
   id: number;
-  user_id: number;
-  friend_id: number;
-  status: "pending" | "accepted" | "blocked";
+  username: string;
+  is_online: boolean;
+  user_id: string;
+  is_pinned: boolean;
   created_at: string;
-  updated_at: string;
-  friend_username?: string;
 }
 
-const toNumericUserID = (token: string): number => {
-  const me = decodeJWT(token);
-  return me?.id ?? 0;
-};
+interface FriendRequestResponse {
+  id: number;
+  from_user_id: string;
+  to_user_id: string;
+  status: "pending" | "accepted" | "declined";
+  created_at: string;
+}
 
 export async function fetchFriendRequests(token: string): Promise<FriendRequest[]> {
-  const response = await fetch(`${API_BASE_URL}/friends/requests/incoming`, {
+  const response = await fetch(`${API_BASE_URL}/friends/requests`, {
     method: "GET",
     headers: headers(token),
   });
@@ -26,21 +28,41 @@ export async function fetchFriendRequests(token: string): Promise<FriendRequest[
     throw new Error("Failed to fetch friend requests");
   }
 
-  const data = (await response.json()) as FriendResponse[];
-  return data.map((item) => ({
+  const payload = (await response.json()) as { friend_requests?: FriendRequestResponse[] };
+  const requests = payload.friend_requests ?? [];
+
+  const requestsWithUsers = await Promise.all(
+    requests.map(async (item) => {
+      try {
+        const fromUser = await getUserInfo(token, item.from_user_id);
+        return {
+          item,
+          fromUsername: fromUser.username,
+        };
+      } catch {
+        return {
+          item,
+          fromUsername: `user-${item.from_user_id}`,
+        };
+      }
+    })
+  );
+
+  return requestsWithUsers.map(({ item, fromUsername }) => ({
     id: item.id,
-    from_user_id: String(item.user_id),
-    from_username: item.friend_username || `user-${item.user_id}`,
-    to_user_id: String(item.friend_id),
-    status: item.status === "blocked" ? "declined" : item.status,
+    from_user_id: item.from_user_id,
+    from_username: fromUsername,
+    to_user_id: item.to_user_id,
+    status: item.status,
     created_at: item.created_at,
   }));
 }
 
-export async function acceptFriendRequest(userId: number, token: string): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}/friends/${userId}/accept`, {
+export async function acceptFriendRequest(requestId: number, token: string): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/friends/accept`, {
     method: "POST",
     headers: headers(token),
+    body: JSON.stringify({ request_id: requestId }),
   });
   if (!response.ok) {
     const errorData = await response.json();
@@ -48,10 +70,11 @@ export async function acceptFriendRequest(userId: number, token: string): Promis
   }
 }
 
-export async function declineFriendRequest(userId: number, token: string): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}/friends/${userId}/reject`, {
-    method: "DELETE",
+export async function declineFriendRequest(requestId: number, token: string): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/friends/decline`, {
+    method: "POST",
     headers: headers(token),
+    body: JSON.stringify({ request_id: requestId }),
   });
   if (!response.ok) {
     const errorData = await response.json();
@@ -59,11 +82,11 @@ export async function declineFriendRequest(userId: number, token: string): Promi
   }
 }
 
-export async function requestFriend(friendUserId: number, token: string): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}/friends/requests`, {
+export async function requestFriend(friendUsername: string, token: string): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/friends/add`, {
     method: "POST",
     headers: headers(token),
-    body: JSON.stringify({ user_id: friendUserId }),
+    body: JSON.stringify({ friend_username: friendUsername }),
   });
   if (!response.ok) {
     const errorData = await response.json();
@@ -80,36 +103,39 @@ export async function fetchFriends(token: string): Promise<Friend[]> {
     throw new Error("Failed to fetch friends");
   }
 
-  const me = toNumericUserID(token);
-  const data = (await response.json()) as FriendResponse[];
-  return data.map((item) => {
-    const friendUserID = item.user_id === me ? item.friend_id : item.user_id;
-    return {
-      id: item.id,
-      user_id: String(friendUserID),
-      friend_user_id: friendUserID,
-      username: item.friend_username || `user-${friendUserID}`,
-      is_online: false,
-      is_pinned: false,
-      created_at: item.created_at,
-    };
-  });
+  const me = decodeJWT(token);
+  const data = (await response.json()) as { friends?: FriendResponse[] };
+  const friends = data.friends ?? [];
+
+  return friends.map((item) => ({
+    id: item.id,
+    user_id: item.user_id,
+    friend_user_id: item.id,
+    username: item.username || `user-${item.user_id}`,
+    is_online: item.is_online,
+    is_pinned: item.is_pinned,
+    created_at: item.created_at,
+  })).filter((item) => item.user_id !== me?.user_id);
 }
 
 export async function addFriend(friendUsername: string, token: string): Promise<void> {
-  void friendUsername;
-  void token;
-  throw new Error("User search/add by username is not implemented on this server");
+  return requestFriend(friendUsername, token);
 }
 
 export async function removeFriend(friendUsername: string, token: string): Promise<void> {
-  void friendUsername;
-  void token;
-  throw new Error("Friend remove endpoint is not implemented on this server");
+  const response = await fetch(`${API_BASE_URL}/friends/remove`, {
+    method: "DELETE",
+    headers: headers(token),
+    body: JSON.stringify({ friend_username: friendUsername }),
+  });
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.error || "Failed to remove friend");
+  }
 }
 
 export async function searchUsers(query: string, token: string, signal?: AbortSignal): Promise<User[]> {
-  const response = await fetch(`${API_BASE_URL}/users/search?q=${encodeURIComponent(query)}`, {
+  const response = await fetch(`${API_BASE_URL}/friends/search?q=${encodeURIComponent(query)}`, {
     method: "GET",
     headers: headers(token),
     signal,
@@ -119,8 +145,10 @@ export async function searchUsers(query: string, token: string, signal?: AbortSi
     throw new Error(errorData.error || "Failed to search users");
   }
 
-  const data = (await response.json()) as { id: number; username: string; name: string }[];
-  return data.map((item) => ({
+  const payload = (await response.json()) as { users?: { id: number; username: string; name: string }[] };
+  const users = payload.users ?? [];
+
+  return users.map((item) => ({
     id: item.id,
     user_id: String(item.id),
     username: item.username,

--- a/src/services/friends-api.ts
+++ b/src/services/friends-api.ts
@@ -83,10 +83,10 @@ export async function declineFriendRequest(requestId: number, token: string): Pr
 }
 
 export async function requestFriend(friendUsername: string, token: string): Promise<void> {
-  const response = await fetch(`${API_BASE_URL}/friends/add`, {
+  const response = await fetch(`${API_BASE_URL}/friends/request`, {
     method: "POST",
     headers: headers(token),
-    body: JSON.stringify({ friend_username: friendUsername }),
+    body: JSON.stringify({ to_username: friendUsername }),
   });
   if (!response.ok) {
     const errorData = await response.json();
@@ -110,7 +110,7 @@ export async function fetchFriends(token: string): Promise<Friend[]> {
   return friends.map((item) => ({
     id: item.id,
     user_id: item.user_id,
-    friend_user_id: item.id,
+    friend_user_id: item.user_id,
     username: item.username || `user-${item.user_id}`,
     is_online: item.is_online,
     is_pinned: item.is_pinned,

--- a/src/services/friends-api.ts
+++ b/src/services/friends-api.ts
@@ -1,5 +1,5 @@
 import { FriendRequest, Friend, User } from "../types";
-import { decodeJWT, getUserInfo, headers } from "./api";
+import { getUserInfo, headers } from "./api";
 import { API_BASE_URL } from "./config";
 
 interface FriendResponse {
@@ -103,7 +103,6 @@ export async function fetchFriends(token: string): Promise<Friend[]> {
     throw new Error("Failed to fetch friends");
   }
 
-  const me = decodeJWT(token);
   const data = (await response.json()) as { friends?: FriendResponse[] };
   const friends = data.friends ?? [];
 
@@ -115,7 +114,7 @@ export async function fetchFriends(token: string): Promise<Friend[]> {
     is_online: item.is_online,
     is_pinned: item.is_pinned,
     created_at: item.created_at,
-  })).filter((item) => item.user_id !== me?.user_id);
+  }));
 }
 
 export async function addFriend(friendUsername: string, token: string): Promise<void> {

--- a/src/services/livekit.ts
+++ b/src/services/livekit.ts
@@ -39,10 +39,12 @@ export interface ParticipantInfo {
   identity: string;
   name: string;
   isLocal: boolean;
-  videoTrack?: Track;
+  cameraTrack?: Track;
+  screenShareTrack?: Track;
   audioTrack?: Track;
   isMuted: boolean;
   isCameraOff: boolean;
+  isScreenSharing: boolean;
 }
 
 export type LiveKitConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
@@ -266,8 +268,6 @@ export class LiveKitClient {
     const cameraPublication = participant.getTrackPublication(Track.Source.Camera);
     const screenShareTrack = screenSharePublication?.track;
     const cameraTrack = cameraPublication?.track;
-    const videoTrack = screenShareTrack || cameraTrack;
-    const videoPublication = screenShareTrack ? screenSharePublication : cameraPublication;
     const audioTrack = participant.getTrackPublication(Track.Source.Microphone)?.track;
 
     return {
@@ -275,10 +275,12 @@ export class LiveKitClient {
       identity: participant.identity,
       name: participant.name || participant.identity,
       isLocal,
-      videoTrack: videoTrack || undefined,
+      cameraTrack: cameraTrack || undefined,
+      screenShareTrack: screenShareTrack || undefined,
       audioTrack: audioTrack || undefined,
       isMuted: participant.getTrackPublication(Track.Source.Microphone)?.isMuted ?? true,
-      isCameraOff: videoPublication?.isMuted ?? true,
+      isCameraOff: cameraPublication?.isMuted ?? true,
+      isScreenSharing: !(screenSharePublication?.isMuted ?? true) && Boolean(screenShareTrack),
     };
   }
 
@@ -461,15 +463,13 @@ export class LiveKitClient {
 
   getLocalVideoTrack(): LocalVideoTrack | null {
     if (!this.room) {
-      return this.screenShareTrack || this.localVideoTrack;
+      return this.localVideoTrack;
     }
 
-    const screenTrack = this.room.localParticipant.getTrackPublication(Track.Source.ScreenShare)
-      ?.track as LocalVideoTrack | undefined;
     const cameraTrack = this.room.localParticipant.getTrackPublication(Track.Source.Camera)
       ?.track as LocalVideoTrack | undefined;
 
-    return screenTrack || cameraTrack || this.screenShareTrack || this.localVideoTrack;
+    return cameraTrack || this.localVideoTrack;
   }
 
   getLocalAudioTrack(): LocalAudioTrack | null {
@@ -477,7 +477,14 @@ export class LiveKitClient {
   }
 
   getScreenShareTrack(): LocalVideoTrack | null {
-    return this.screenShareTrack;
+    if (!this.room) {
+      return this.screenShareTrack;
+    }
+
+    const screenTrack = this.room.localParticipant.getTrackPublication(Track.Source.ScreenShare)
+      ?.track as LocalVideoTrack | undefined;
+
+    return screenTrack || this.screenShareTrack;
   }
 
   isMicEnabled(): boolean {

--- a/src/services/livekit.ts
+++ b/src/services/livekit.ts
@@ -14,7 +14,6 @@ import {
   ConnectionState,
   LocalVideoTrack,
   LocalAudioTrack,
-  createLocalTracks,
   VideoPresets,
 } from 'livekit-client';
 
@@ -93,6 +92,23 @@ export class LiveKitClient {
   private isCameraMuted = false;
   private isScreenSharing = false;
 
+  private ensureMediaDevicesAvailable(feature: 'microphone' | 'camera' | 'screen share'): void {
+    if (feature === 'screen share') {
+      if (!navigator.mediaDevices?.getDisplayMedia) {
+        throw new Error('Screen sharing is not available in this browser or context');
+      }
+      return;
+    }
+
+    if (!window.isSecureContext) {
+      throw new Error(`${feature === 'microphone' ? 'Microphone' : 'Camera'} requires a secure HTTPS connection`);
+    }
+
+    if (!navigator.mediaDevices?.getUserMedia) {
+      throw new Error(`${feature === 'microphone' ? 'Microphone' : 'Camera'} is not available in this browser or context`);
+    }
+  }
+
   // === Connection Management ===
 
   async connect(credentials: LiveKitCredentials): Promise<void> {
@@ -121,18 +137,19 @@ export class LiveKitClient {
   }
 
   async disconnect(): Promise<void> {
+    const room = this.room;
+
     // Unpublish local tracks
     await this.stopCamera();
     await this.stopMic();
     await this.stopScreenShare();
 
-    if (this.room) {
-      this.room.disconnect();
+    if (room) {
+      room.disconnect();
       this.room = null;
     }
 
     this.credentials = null;
-    this.handlers.onDisconnected?.();
   }
 
   private setupEventListeners(): void {
@@ -278,21 +295,15 @@ export class LiveKitClient {
     }
 
     try {
-      if (!this.localVideoTrack) {
-        const tracks = await createLocalTracks({
-          video: { resolution: VideoPresets.h720.resolution },
-          audio: false,
-        });
-        this.localVideoTrack = tracks.find(
-          (t) => t.kind === Track.Kind.Video
-        ) as LocalVideoTrack | undefined ?? null;
-      }
+      this.ensureMediaDevicesAvailable('camera');
+      await this.room.localParticipant.setCameraEnabled(true, {
+        resolution: VideoPresets.h720.resolution,
+      });
 
-      if (this.localVideoTrack) {
-        await this.room.localParticipant.publishTrack(this.localVideoTrack);
-        this.isCameraMuted = false;
-        this.handlers.onCameraMuted?.(false);
-      }
+      const publication = this.room.localParticipant.getTrackPublication(Track.Source.Camera);
+      this.localVideoTrack = (publication?.track as LocalVideoTrack | undefined) ?? null;
+      this.isCameraMuted = false;
+      this.handlers.onCameraMuted?.(false);
     } catch (err) {
       this.handleError(err instanceof Error ? err : new Error(String(err)));
       throw err;
@@ -300,9 +311,8 @@ export class LiveKitClient {
   }
 
   async disableCamera(): Promise<void> {
-    if (this.localVideoTrack && this.room) {
-      await this.room.localParticipant.unpublishTrack(this.localVideoTrack);
-      this.localVideoTrack.stop();
+    if (this.room) {
+      await this.room.localParticipant.setCameraEnabled(false);
       this.localVideoTrack = null;
       this.isCameraMuted = true;
       this.handlers.onCameraMuted?.(true);
@@ -324,21 +334,13 @@ export class LiveKitClient {
     }
 
     try {
-      if (!this.localAudioTrack) {
-        const tracks = await createLocalTracks({
-          video: false,
-          audio: true,
-        });
-        this.localAudioTrack = tracks.find(
-          (t) => t.kind === Track.Kind.Audio
-        ) as LocalAudioTrack | undefined ?? null;
-      }
+      this.ensureMediaDevicesAvailable('microphone');
+      await this.room.localParticipant.setMicrophoneEnabled(true);
 
-      if (this.localAudioTrack) {
-        await this.room.localParticipant.publishTrack(this.localAudioTrack);
-        this.isMicMuted = false;
-        this.handlers.onMicMuted?.(false);
-      }
+      const publication = this.room.localParticipant.getTrackPublication(Track.Source.Microphone);
+      this.localAudioTrack = (publication?.track as LocalAudioTrack | undefined) ?? null;
+      this.isMicMuted = false;
+      this.handlers.onMicMuted?.(false);
     } catch (err) {
       this.handleError(err instanceof Error ? err : new Error(String(err)));
       throw err;
@@ -346,9 +348,8 @@ export class LiveKitClient {
   }
 
   async disableMic(): Promise<void> {
-    if (this.localAudioTrack && this.room) {
-      await this.room.localParticipant.unpublishTrack(this.localAudioTrack);
-      this.localAudioTrack.stop();
+    if (this.room) {
+      await this.room.localParticipant.setMicrophoneEnabled(false);
       this.localAudioTrack = null;
       this.isMicMuted = true;
       this.handlers.onMicMuted?.(true);
@@ -374,6 +375,7 @@ export class LiveKitClient {
     }
 
     try {
+      this.ensureMediaDevicesAvailable('screen share');
       const publication = await this.room.localParticipant.setScreenShareEnabled(true);
       const publicationTrack = publication?.track as LocalVideoTrack | undefined;
       const fallbackTrack = this.room.localParticipant.getTrackPublication(Track.Source.ScreenShare)

--- a/src/services/livekit.ts
+++ b/src/services/livekit.ts
@@ -25,6 +25,7 @@ export interface LiveKitCredentials {
   roomName: string;
 }
 
+// TrackInfo describes one published or subscribed LiveKit track.
 export interface TrackInfo {
   trackSid: string;
   participantId: string;
@@ -34,6 +35,7 @@ export interface TrackInfo {
   track: Track;
 }
 
+// ParticipantInfo describes the media state for a single LiveKit participant.
 export interface ParticipantInfo {
   sid: string;
   identity: string;
@@ -47,6 +49,7 @@ export interface ParticipantInfo {
   isScreenSharing: boolean;
 }
 
+// LiveKitConnectionState is the simplified room connection state exposed to the app.
 export type LiveKitConnectionState = 'disconnected' | 'connecting' | 'connected' | 'reconnecting';
 
 // === Event Handlers ===

--- a/src/services/livekit.ts
+++ b/src/services/livekit.ts
@@ -93,8 +93,8 @@ export class LiveKitClient {
   private localVideoTrack: LocalVideoTrack | null = null;
   private localAudioTrack: LocalAudioTrack | null = null;
   private screenShareTrack: LocalVideoTrack | null = null;
-  private isMicMuted = false;
-  private isCameraMuted = false;
+  private isMicMuted = true;
+  private isCameraMuted = true;
   private isScreenSharing = false;
 
   private ensureMediaDevicesAvailable(feature: 'microphone' | 'camera' | 'screen share'): void {
@@ -134,6 +134,8 @@ export class LiveKitClient {
 
     try {
       await this.room.connect(credentials.url, credentials.token);
+      this.handlers.onMicMuted?.(true);
+      this.handlers.onCameraMuted?.(true);
       this.handlers.onConnected?.();
     } catch (err) {
       this.handleError(err instanceof Error ? err : new Error(String(err)));

--- a/src/services/rooms-api.ts
+++ b/src/services/rooms-api.ts
@@ -40,6 +40,14 @@ export interface RoomStateResponse {
   in_voice: boolean;
 }
 
+export interface RoomVoiceCredentialsResponse {
+  url: string;
+  token: string;
+  room_name: string;
+  identity: string;
+  name: string;
+}
+
 // Функция для получения списка приглашений в комнаты (GET /api/rooms/invites)
 export async function fetchRoomInvites(token: string): Promise<RoomInvite[]> {
   void token;
@@ -177,6 +185,21 @@ export async function updateRoomVoiceMedia(
     const errorData = await response.json().catch(() => ({}));
     throw new Error(errorData.error || "Failed to update room voice media");
   }
+}
+
+export async function fetchRoomVoiceCredentials(
+  roomID: string,
+  token: string
+): Promise<RoomVoiceCredentialsResponse> {
+  const response = await fetch(`${API_BASE_URL}/rooms/${roomID}/voice/credentials`, {
+    method: "GET",
+    headers: headers(token),
+  });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || "Failed to fetch room voice credentials");
+  }
+  return response.json();
 }
 
 /** Получаем приглашённые комнаты - not implemented in WireChat */

--- a/src/services/rooms-api.ts
+++ b/src/services/rooms-api.ts
@@ -16,6 +16,7 @@ async function getAPIError(response: Response, fallback: string): Promise<string
   return message;
 }
 
+// RoomMemberState represents one room member in the room state response.
 export interface RoomMemberState {
   id: number;
   user_id: string;
@@ -26,6 +27,7 @@ export interface RoomMemberState {
   joined_at: string;
 }
 
+// RoomVoiceParticipantState represents one active room voice participant.
 export interface RoomVoiceParticipantState {
   id: number;
   user_id: string;
@@ -39,6 +41,7 @@ export interface RoomVoiceParticipantState {
   updated_at: string;
 }
 
+// RoomStateResponse contains room metadata, members, and room voice presence.
 export interface RoomStateResponse {
   room: {
     id: number;
@@ -54,6 +57,7 @@ export interface RoomStateResponse {
   in_voice: boolean;
 }
 
+// RoomVoiceCredentialsResponse contains LiveKit join credentials for room voice.
 export interface RoomVoiceCredentialsResponse {
   url: string;
   token: string;
@@ -149,6 +153,7 @@ export async function joinRoomAsMember(roomID: string, token: string): Promise<v
   }
 }
 
+// fetchRoomState returns the current room metadata and room voice presence snapshot.
 export async function fetchRoomState(roomID: string, token: string): Promise<RoomStateResponse> {
   const response = await fetch(`${API_BASE_URL}/rooms/${roomID}/state`, {
     method: "GET",
@@ -160,6 +165,7 @@ export async function fetchRoomState(roomID: string, token: string): Promise<Roo
   return response.json();
 }
 
+// joinRoomVoice creates room-scoped voice presence for the current user.
 export async function joinRoomVoice(roomID: string, token: string): Promise<void> {
   const response = await fetch(`${API_BASE_URL}/rooms/${roomID}/voice/join`, {
     method: "POST",
@@ -170,6 +176,7 @@ export async function joinRoomVoice(roomID: string, token: string): Promise<void
   }
 }
 
+// leaveRoomVoice removes room-scoped voice presence for the current user.
 export async function leaveRoomVoice(roomID: string, token: string): Promise<void> {
   const response = await fetch(`${API_BASE_URL}/rooms/${roomID}/voice/leave`, {
     method: "POST",
@@ -180,6 +187,7 @@ export async function leaveRoomVoice(roomID: string, token: string): Promise<voi
   }
 }
 
+// updateRoomVoiceMedia updates room voice media flags for the current user.
 export async function updateRoomVoiceMedia(
   roomID: string,
   payload: {
@@ -199,6 +207,7 @@ export async function updateRoomVoiceMedia(
   }
 }
 
+// fetchRoomVoiceCredentials fetches LiveKit credentials for the current room voice session.
 export async function fetchRoomVoiceCredentials(
   roomID: string,
   token: string

--- a/src/services/rooms-api.ts
+++ b/src/services/rooms-api.ts
@@ -113,9 +113,14 @@ export async function createRoom(name: string, token: string): Promise<Room> {
 
 /** Удаление комнаты (DELETE /rooms/:id) */
 export async function deleteRoom(roomID: string, token: string): Promise<void> {
-  void roomID;
-  void token;
-  throw new Error("Room delete endpoint is not implemented on this server");
+  const response = await fetch(`${API_BASE_URL}/rooms/${roomID}`, {
+    method: "DELETE",
+    headers: headers(token),
+  });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || "Failed to delete room");
+  }
 }
 
 /** Join room as member (POST /rooms/:id/join) - required for calls */

--- a/src/services/rooms-api.ts
+++ b/src/services/rooms-api.ts
@@ -239,23 +239,24 @@ export async function updateRoom(roomID: string, name: string, token: string): P
 }
 
 /** Create or get direct message room with a user (POST /rooms/direct) */
-export interface DirectRoomResponse {
-  id: number;
-  name: string;
-  type: string;
-  owner_id: number | null;
-  created_at: string;
-}
-
-export async function getOrCreateDirectRoom(userId: number, token: string): Promise<DirectRoomResponse> {
+export async function getOrCreateDirectRoom(userId: string, token: string): Promise<Room> {
   const response = await fetch(`${API_BASE_URL}/rooms/direct`, {
     method: "POST",
     headers: headers(token),
-    body: JSON.stringify({ user_id: userId }),
+    body: JSON.stringify({ friend_user_id: userId }),
   });
   if (!response.ok) {
     const errorData = await response.json();
     throw new Error(errorData.error || "Failed to create direct room");
   }
-  return response.json();
+  const payload = await response.json();
+  const room = payload.room ?? payload;
+
+  return {
+    room_id: room.room_id,
+    user_id: room.user_id,
+    name: room.name,
+    type: room.type,
+    created_at: room.created_at,
+  };
 }

--- a/src/services/rooms-api.ts
+++ b/src/services/rooms-api.ts
@@ -66,6 +66,75 @@ export interface RoomVoiceCredentialsResponse {
   name: string;
 }
 
+const normalizeRoom = (payload: {
+  room_id: string;
+  user_id: string;
+  name: string;
+  type: string;
+  created_at: string;
+}): Room => ({
+  room_id: payload.room_id,
+  user_id: payload.user_id,
+  name: payload.name,
+  type: payload.type,
+  created_at: payload.created_at,
+});
+
+async function fetchRoom(roomID: string, token: string): Promise<Room> {
+  const response = await fetch(`${API_BASE_URL}/rooms/${roomID}`, {
+    method: "GET",
+    headers: headers(token),
+  });
+  if (!response.ok) {
+    throw new Error(await getAPIError(response, "Failed to fetch room"));
+  }
+
+  const payload = (await response.json()) as {
+    room?: {
+      room_id: string;
+      user_id: string;
+      name: string;
+      type: string;
+      created_at: string;
+    };
+  };
+
+  if (!payload.room) {
+    throw new Error("Room payload is missing in response");
+  }
+
+  return normalizeRoom(payload.room);
+}
+
+async function fetchRoomUpdatePayload(
+  roomID: string,
+  token: string
+): Promise<{ type: string; password: string }> {
+  const response = await fetch(`${API_BASE_URL}/rooms/${roomID}`, {
+    method: "GET",
+    headers: headers(token),
+  });
+  if (!response.ok) {
+    throw new Error(await getAPIError(response, "Failed to fetch room"));
+  }
+
+  const payload = (await response.json()) as {
+    room?: {
+      type?: string;
+      password?: string;
+    };
+  };
+
+  if (!payload.room?.type) {
+    throw new Error("Room update payload is missing in response");
+  }
+
+  return {
+    type: payload.room.type,
+    password: typeof payload.room.password === "string" ? payload.room.password : "",
+  };
+}
+
 // Функция для получения списка приглашений в комнаты (GET /api/rooms/invites)
 export async function fetchRoomInvites(token: string): Promise<RoomInvite[]> {
   void token;
@@ -118,14 +187,12 @@ export async function createRoom(name: string, token: string): Promise<Room> {
   if (!response.ok) {
     throw new Error(await getAPIError(response, "Failed to create room"));
   }
-  const data = await response.json();
-  return {
-    room_id: data.roomID,
-    name: data.name,
-    type: data.type,
-    user_id: "",
-    created_at: new Date().toISOString(),
-  };
+  const data = (await response.json()) as { roomID?: string };
+  if (!data.roomID) {
+    throw new Error("Created room ID is missing in response");
+  }
+
+  return fetchRoom(data.roomID, token);
 }
 
 /** Удаление комнаты (DELETE /rooms/:id) */
@@ -247,10 +314,15 @@ export async function inviteFriendToRoom(
 
 /** Обновление комнаты (PUT /rooms/:id) */
 export async function updateRoom(roomID: string, name: string, token: string): Promise<void> {
+  const currentRoom = await fetchRoomUpdatePayload(roomID, token);
   const response = await fetch(`${API_BASE_URL}/rooms/${roomID}`, {
     method: "PUT",
     headers: headers(token),
-    body: JSON.stringify({ name, type: "public", password: "" }),
+    body: JSON.stringify({
+      name,
+      type: currentRoom.type,
+      password: currentRoom.password,
+    }),
   });
   if (!response.ok) {
     const errorData = await response.json().catch(() => ({}));

--- a/src/services/rooms-api.ts
+++ b/src/services/rooms-api.ts
@@ -2,6 +2,44 @@ import { RoomInvite, Room } from "../types";
 import { headers } from "./api";
 import { API_BASE_URL } from "./config";
 
+export interface RoomMemberState {
+  id: number;
+  user_id: string;
+  username: string;
+  name: string;
+  is_online: boolean;
+  role: string;
+  joined_at: string;
+}
+
+export interface RoomVoiceParticipantState {
+  id: number;
+  user_id: string;
+  username: string;
+  name: string;
+  is_online: boolean;
+  is_mic_enabled: boolean;
+  is_camera_enabled: boolean;
+  is_screen_sharing: boolean;
+  joined_at: string;
+  updated_at: string;
+}
+
+export interface RoomStateResponse {
+  room: {
+    id: number;
+    room_id: string;
+    user_id: string;
+    name: string;
+    type: string;
+    password: string;
+    created_at: string;
+  };
+  members: RoomMemberState[];
+  voice_participants: RoomVoiceParticipantState[];
+  in_voice: boolean;
+}
+
 // Функция для получения списка приглашений в комнаты (GET /api/rooms/invites)
 export async function fetchRoomInvites(token: string): Promise<RoomInvite[]> {
   void token;
@@ -24,7 +62,7 @@ export async function declineRoomInvite(inviteId: number, token: string): Promis
 
 /** Получаем комнаты пользователя (GET /rooms) */
 export async function fetchMyRooms(token: string): Promise<Room[]> {
-  const response = await fetch(`${API_BASE_URL}/rooms`, {
+  const response = await fetch(`${API_BASE_URL}/rooms/mine`, {
     method: "GET",
     headers: headers(token),
   });
@@ -34,9 +72,9 @@ export async function fetchMyRooms(token: string): Promise<Room[]> {
   const data = await response.json();
   // Server returns array directly, or { rooms: [...] }
   const rooms = Array.isArray(data) ? data : (Array.isArray(data.rooms) ? data.rooms : []);
-  return rooms.map((r: { id: number; name: string; type: string; owner_id: number | null; created_at: string }) => ({
-    room_id: String(r.id),
-    user_id: r.owner_id ? String(r.owner_id) : '',
+  return rooms.map((r: { id?: number; room_id: string; name: string; type: string; user_id: string; created_at: string }) => ({
+    room_id: r.room_id,
+    user_id: r.user_id,
     name: r.name,
     type: r.type,
     created_at: r.created_at,
@@ -46,7 +84,7 @@ export async function fetchMyRooms(token: string): Promise<Room[]> {
 /** Создание комнаты (POST /rooms) */
 export async function createRoom(name: string, token: string): Promise<Room> {
   const type = "public"; // можно расширить по необходимости
-  const response = await fetch(`${API_BASE_URL}/rooms`, {
+  const response = await fetch(`${API_BASE_URL}/rooms/create`, {
     method: "POST",
     headers: headers(token),
     body: JSON.stringify({ name, type }),
@@ -57,11 +95,11 @@ export async function createRoom(name: string, token: string): Promise<Room> {
   }
   const data = await response.json();
   return {
-    room_id: String(data.id),
+    room_id: data.roomID,
     name: data.name,
     type: data.type,
-    user_id: String(data.owner_id),
-    created_at: data.created_at,
+    user_id: "",
+    created_at: new Date().toISOString(),
   };
 }
 
@@ -87,6 +125,60 @@ export async function joinRoomAsMember(roomID: string, token: string): Promise<v
   }
 }
 
+export async function fetchRoomState(roomID: string, token: string): Promise<RoomStateResponse> {
+  const response = await fetch(`${API_BASE_URL}/rooms/${roomID}/state`, {
+    method: "GET",
+    headers: headers(token),
+  });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || "Failed to fetch room state");
+  }
+  return response.json();
+}
+
+export async function joinRoomVoice(roomID: string, token: string): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/rooms/${roomID}/voice/join`, {
+    method: "POST",
+    headers: headers(token),
+  });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || "Failed to join room voice");
+  }
+}
+
+export async function leaveRoomVoice(roomID: string, token: string): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/rooms/${roomID}/voice/leave`, {
+    method: "POST",
+    headers: headers(token),
+  });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || "Failed to leave room voice");
+  }
+}
+
+export async function updateRoomVoiceMedia(
+  roomID: string,
+  payload: {
+    is_mic_enabled?: boolean;
+    is_camera_enabled?: boolean;
+    is_screen_sharing?: boolean;
+  },
+  token: string
+): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/rooms/${roomID}/voice/media`, {
+    method: "PUT",
+    headers: headers(token),
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || "Failed to update room voice media");
+  }
+}
+
 /** Получаем приглашённые комнаты - not implemented in WireChat */
 export async function fetchInvitedRooms(_token: string): Promise<Room[]> {
   // Room invites not implemented in WireChat server - return empty array
@@ -99,18 +191,28 @@ export async function inviteFriendToRoom(
   username: string,
   token: string
 ): Promise<void> {
-  void roomID;
-  void username;
-  void token;
-  throw new Error("Room invite endpoint is not implemented on this server");
+  const response = await fetch(`${API_BASE_URL}/rooms/invite`, {
+    method: "POST",
+    headers: headers(token),
+    body: JSON.stringify({ roomID, username }),
+  });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || "Failed to invite friend to room");
+  }
 }
 
 /** Обновление комнаты (PUT /rooms/:id) */
 export async function updateRoom(roomID: string, name: string, token: string): Promise<void> {
-  void roomID;
-  void name;
-  void token;
-  throw new Error("Room update endpoint is not implemented on this server");
+  const response = await fetch(`${API_BASE_URL}/rooms/${roomID}`, {
+    method: "PUT",
+    headers: headers(token),
+    body: JSON.stringify({ name, type: "public", password: "" }),
+  });
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw new Error(errorData.error || "Failed to update room");
+  }
 }
 
 /** Create or get direct message room with a user (POST /rooms/direct) */

--- a/src/services/rooms-api.ts
+++ b/src/services/rooms-api.ts
@@ -2,6 +2,20 @@ import { RoomInvite, Room } from "../types";
 import { headers } from "./api";
 import { API_BASE_URL } from "./config";
 
+async function getAPIError(response: Response, fallback: string): Promise<string> {
+  const errorData = await response.json().catch(() => ({}));
+  const message =
+    typeof errorData.error === "string" && errorData.error.length > 0
+      ? errorData.error
+      : fallback;
+
+  if (response.status === 401) {
+    return `Session expired: ${message}`;
+  }
+
+  return message;
+}
+
 export interface RoomMemberState {
   id: number;
   user_id: string;
@@ -98,8 +112,7 @@ export async function createRoom(name: string, token: string): Promise<Room> {
     body: JSON.stringify({ name, type }),
   });
   if (!response.ok) {
-    const errorData = await response.json();
-    throw new Error(errorData.error || "Failed to create room");
+    throw new Error(await getAPIError(response, "Failed to create room"));
   }
   const data = await response.json();
   return {
@@ -118,8 +131,7 @@ export async function deleteRoom(roomID: string, token: string): Promise<void> {
     headers: headers(token),
   });
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(errorData.error || "Failed to delete room");
+    throw new Error(await getAPIError(response, "Failed to delete room"));
   }
 }
 
@@ -130,10 +142,9 @@ export async function joinRoomAsMember(roomID: string, token: string): Promise<v
     headers: headers(token),
   });
   if (!response.ok) {
-    // Ignore "already a member" errors
-    const errorData = await response.json();
-    if (!errorData.error?.includes("already")) {
-      throw new Error(errorData.error || "Failed to join room");
+    const message = await getAPIError(response, "Failed to join room");
+    if (!message.toLowerCase().includes("already")) {
+      throw new Error(message);
     }
   }
 }
@@ -144,8 +155,7 @@ export async function fetchRoomState(roomID: string, token: string): Promise<Roo
     headers: headers(token),
   });
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(errorData.error || "Failed to fetch room state");
+    throw new Error(await getAPIError(response, "Failed to fetch room state"));
   }
   return response.json();
 }
@@ -156,8 +166,7 @@ export async function joinRoomVoice(roomID: string, token: string): Promise<void
     headers: headers(token),
   });
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(errorData.error || "Failed to join room voice");
+    throw new Error(await getAPIError(response, "Failed to join room voice"));
   }
 }
 
@@ -167,8 +176,7 @@ export async function leaveRoomVoice(roomID: string, token: string): Promise<voi
     headers: headers(token),
   });
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(errorData.error || "Failed to leave room voice");
+    throw new Error(await getAPIError(response, "Failed to leave room voice"));
   }
 }
 
@@ -187,8 +195,7 @@ export async function updateRoomVoiceMedia(
     body: JSON.stringify(payload),
   });
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(errorData.error || "Failed to update room voice media");
+    throw new Error(await getAPIError(response, "Failed to update room voice media"));
   }
 }
 
@@ -201,8 +208,7 @@ export async function fetchRoomVoiceCredentials(
     headers: headers(token),
   });
   if (!response.ok) {
-    const errorData = await response.json().catch(() => ({}));
-    throw new Error(errorData.error || "Failed to fetch room voice credentials");
+    throw new Error(await getAPIError(response, "Failed to fetch room voice credentials"));
   }
   return response.json();
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,12 +10,14 @@ export interface User {
   created_at: string;
 }
 
+// UserInfo is the minimal user lookup payload used by lightweight API responses.
 export interface UserInfo {
   id: number;
   username: string;
   name: string;
 }
 
+// Room describes a room entry returned by room list and create endpoints.
 export interface Room {
   room_id: string;
   user_id: string; // можно использовать string (UUID)
@@ -25,6 +27,7 @@ export interface Room {
   is_owner?: boolean;
 }
 
+// RoomMember describes a member entry in room membership lists.
 export interface RoomMember {
   id: number;
   room_id: string;
@@ -52,6 +55,7 @@ export interface Friend {
   created_at: string;
 }
 
+// FriendRequest describes an incoming or outgoing friend request.
 export interface FriendRequest {
   id: number;
   from_user_id: string;
@@ -61,6 +65,7 @@ export interface FriendRequest {
   created_at: string;
 }
 
+// RoomInvite describes a pending invitation to join a room.
 export interface RoomInvite {
   id: number;
   room_id: string;
@@ -70,6 +75,7 @@ export interface RoomInvite {
   created_at: string;
 }
 
+// IChatMessageResponse describes one persisted direct chat message.
 export interface IChatMessageResponse {
   id: number,
   sender_id: string,
@@ -78,6 +84,7 @@ export interface IChatMessageResponse {
   created_at: string,
 }
 
+// ConversationInfo describes one direct-message conversation preview.
 export interface ConversationInfo {
   user_id: string;
   username: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,3 +77,11 @@ export interface IChatMessageResponse {
   text: string,
   created_at: string,
 }
+
+export interface ConversationInfo {
+  user_id: string;
+  username: string;
+  name: string;
+  last_message: string;
+  last_message_at: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,7 @@ export interface Friend {
   username: string;
   is_online: boolean;
   user_id: string; // kept for route params compatibility
-  friend_user_id: number; // numeric target user id for DM/calls
+  friend_user_id: string; // target user UUID for DM/private room flows
   is_pinned: boolean;
   created_at: string;
 }


### PR DESCRIPTION
## Summary

Stabilize client auth/session handling, align chat and room flows with the current backend API, and polish room voice rendering.

## Changes

- hydrate the authenticated user from `/api/user/me` and stop relying on incomplete JWT payload data in room and auth state
- handle room voice session expiry explicitly instead of silently degrading after `401` responses
- fix signup success flow so the success state remains visible after registration
- align client chat history requests with the current API by removing the legacy `token` query requirement
- improve room voice tile rendering so local camera state is reflected immediately and returns to `Voice only` when disabled
- update room and dock mic/camera controls to show the next action
- show screen share as a separate room tile while keeping the participant camera/voice tile visible
- split LiveKit participant media state into distinct camera and screen-share tracks for room rendering

## Verification

- `npm run build`
- manually verified login and session hydration after fresh auth
- manually verified room voice join/leave remains stable in two local browser windows
- manually verified camera on/off updates participant tiles correctly
- manually verified screen share renders as a separate tile while the user tile remains visible
