### PR TITLE
Add room tile focus, fullscreen, and speaking indicators

### DIFF
--- a/docs/superpowers/specs/2026-04-09-room-speaking-indicator-design.md
+++ b/docs/superpowers/specs/2026-04-09-room-speaking-indicator-design.md
@@ -1,0 +1,109 @@
+# Room Speaking Indicator Design
+
+## Summary
+
+Add Discord-like speaking indicators to room tiles in `RoomPage`.
+
+The indicator should be a green outline with a short hold after speech stops so tiles do not flicker.
+
+The speaking source depends on tile type:
+
+- `camera tile` and `voice-only card`: react to the participant's microphone speech activity
+- `screen-share tile`: react only to the screen-share audio track, not to the owner's microphone
+
+## Goals
+
+- Show who is actively speaking in the room
+- Keep the behavior visually close to Discord
+- Apply the indicator consistently in normal grid mode and focus mode
+- Distinguish participant speech from screen-share/system-audio activity
+
+## Non-Goals
+
+- No backend changes
+- No changes to room voice transport
+- No waveform or VU-meter UI
+
+## State Model
+
+`RoomVoiceContext` should expose two short-lived activity states:
+
+- `activeSpeakerIds: string[]`
+- `activeScreenShareSpeakerIds: string[]`
+
+Both should use a short hold window so the highlight remains visible briefly after activity stops.
+
+Recommended hold window:
+
+- `1000ms`
+
+## Activity Sources
+
+### Participant Speech
+
+Participant microphone activity should come from LiveKit active-speaker data.
+
+This state applies to:
+
+- camera tiles
+- voice-only participant cards
+
+### Screen Share Audio
+
+Screen-share tiles must not inherit the participant's microphone speaking state.
+
+A screen-share tile should be highlighted only when:
+
+- the screen share is publishing its own audio
+- and that screen-share audio is currently active
+
+If screen share has no audio track, its tile should never receive the speaking outline.
+
+## UI Behavior
+
+When a tile is considered active:
+
+- apply a green ring
+- apply a soft green outer glow
+
+The same visual treatment should work for:
+
+- camera tiles
+- voice-only participant cards
+- screen-share tiles
+- focused tiles
+- tiles in the bottom focus strip
+
+## Tile Rules
+
+### Camera Tile
+
+Highlight when the participant is actively speaking on microphone input.
+
+### Voice-Only Card
+
+Highlight when the participant is actively speaking on microphone input.
+
+### Screen-Share Tile
+
+Highlight only when the shared screen audio is active.
+
+Do not highlight the screen-share tile because the owner is talking on microphone.
+
+## Error Handling
+
+- If active-speaker data is unavailable, tiles should fall back to no speaking outline
+- Missing screen-share audio must not affect normal screen-share rendering
+- Speaking-indicator failures must not affect room voice controls or focus mode
+
+## Testing
+
+Manual verification should cover:
+
+1. A participant talks on microphone and their camera tile gets a green outline
+2. A participant with no camera talks and their voice-only card gets a green outline
+3. A participant with camera + screen share talks on microphone and only the participant tile is highlighted
+4. A participant shares screen audio and the screen-share tile gets a green outline
+5. A participant shares screen without audio and the screen-share tile never gets a green outline
+6. Speaking indicators remain visible briefly after speech stops
+7. The same behavior works in focus mode and in the bottom tile strip

--- a/src/context/RoomVoiceContext.tsx
+++ b/src/context/RoomVoiceContext.tsx
@@ -397,6 +397,25 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
     resetState(leaveError);
   }, [handleSessionFailure, isSessionError, resetState, state.roomId, token]);
 
+  const syncMediaState = useCallback(
+    async (
+      patch: {
+        is_mic_enabled?: boolean;
+        is_camera_enabled?: boolean;
+        is_screen_sharing?: boolean;
+      },
+      roomIdOverride?: string
+    ) => {
+      const roomId = roomIdOverride ?? state.roomId;
+      if (!token || !roomId) {
+        return;
+      }
+
+      await updateRoomVoiceMedia(roomId, patch, token);
+    },
+    [state.roomId, token]
+  );
+
   const joinRoomVoiceSession = useCallback(
     async (roomId: string, roomName?: string) => {
       if (!token) {
@@ -468,6 +487,9 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
           },
           onScreenShareStopped: () => {
             setState((current) => ({ ...current, screenSharing: false }));
+            void syncMediaState({ is_screen_sharing: false }, roomId).catch((error) => {
+              console.warn("[RoomVoiceContext] Failed to sync stopped screen share:", error);
+            });
             syncParticipants();
           },
           onError: (error) => {
@@ -496,22 +518,7 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
         resetState(message);
       }
     },
-    [handleSessionFailure, isSessionError, leaveRoomVoiceSession, resetState, state.roomId, syncParticipants, token]
-  );
-
-  const syncMediaState = useCallback(
-    async (patch: {
-      is_mic_enabled?: boolean;
-      is_camera_enabled?: boolean;
-      is_screen_sharing?: boolean;
-    }) => {
-      if (!token || !state.roomId) {
-        return;
-      }
-
-      await updateRoomVoiceMedia(state.roomId, patch, token);
-    },
-    [state.roomId, token]
+    [handleSessionFailure, isSessionError, leaveRoomVoiceSession, resetState, state.roomId, syncMediaState, syncParticipants, token]
   );
 
   const toggleRoomVoiceMic = useCallback(async () => {

--- a/src/context/RoomVoiceContext.tsx
+++ b/src/context/RoomVoiceContext.tsx
@@ -29,6 +29,8 @@ export interface RoomVoiceState {
   roomId: string | null;
   roomName: string | null;
   participants: ParticipantInfo[];
+  activeSpeakerIds: string[];
+  activeScreenShareSpeakerIds: string[];
   localMuted: boolean;
   localCameraOff: boolean;
   screenSharing: boolean;
@@ -41,6 +43,8 @@ const initialState: RoomVoiceState = {
   roomId: null,
   roomName: null,
   participants: [],
+  activeSpeakerIds: [],
+  activeScreenShareSpeakerIds: [],
   localMuted: true,
   localCameraOff: true,
   screenSharing: false,
@@ -69,6 +73,33 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const { token, logout } = useAuth();
   const clientRef = useRef<LiveKitClient | null>(null);
+  const activityHoldMs = 1000;
+  const speakerActivityRef = useRef<Map<string, number>>(new Map());
+  const screenShareActivityRef = useRef<Map<string, number>>(new Map());
+  const micAnalyserRef = useRef<
+    Map<
+      string,
+      {
+        participantId: string;
+        audioContext: AudioContext;
+        analyser: AnalyserNode;
+        source: MediaStreamAudioSourceNode;
+        data: Uint8Array;
+      }
+    >
+  >(new Map());
+  const screenShareAnalyserRef = useRef<
+    Map<
+      string,
+      {
+        participantId: string;
+        audioContext: AudioContext;
+        analyser: AnalyserNode;
+        source: MediaStreamAudioSourceNode;
+        data: Uint8Array;
+      }
+    >
+  >(new Map());
   const [state, setState] = useState<RoomVoiceState>(initialState);
 
   const isSessionError = useCallback((message: string) => {
@@ -80,18 +111,245 @@ export const RoomVoiceProvider: React.FC<{ children: React.ReactNode }> = ({
     setState((current) => ({ ...current, participants }));
   }, []);
 
+  const syncHeldActivity = useCallback(() => {
+    const now = Date.now();
+
+    const activeSpeakerIds = Array.from(speakerActivityRef.current.entries())
+      .filter(([, timestamp]) => now - timestamp < activityHoldMs)
+      .map(([participantId]) => participantId);
+    const activeScreenShareSpeakerIds = Array.from(screenShareActivityRef.current.entries())
+      .filter(([, timestamp]) => now - timestamp < activityHoldMs)
+      .map(([participantId]) => participantId);
+
+    setState((current) => ({
+      ...current,
+      activeSpeakerIds,
+      activeScreenShareSpeakerIds,
+    }));
+  }, [activityHoldMs]);
+
+  const calculateRms = useCallback((data: Uint8Array) => {
+    let sum = 0;
+
+    for (let index = 0; index < data.length; index += 1) {
+      const normalized = (data[index] - 128) / 128;
+      sum += normalized * normalized;
+    }
+
+    return Math.sqrt(sum / Math.max(data.length, 1));
+  }, []);
+
   useEffect(() => {
     if (!clientRef.current) {
       clientRef.current = createLiveKitClient();
     }
 
     return () => {
+      micAnalyserRef.current.forEach(({ source, audioContext }) => {
+        source.disconnect();
+        void audioContext.close();
+      });
+      micAnalyserRef.current.clear();
+      screenShareAnalyserRef.current.forEach(({ source, audioContext }) => {
+        source.disconnect();
+        void audioContext.close();
+      });
+      screenShareAnalyserRef.current.clear();
       void clientRef.current?.disconnect();
       clientRef.current?.clearHandlers();
     };
   }, []);
 
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      syncHeldActivity();
+    }, 150);
+
+    return () => window.clearInterval(interval);
+  }, [syncHeldActivity]);
+
+  useEffect(() => {
+    const nextParticipantIds = new Set(
+      state.participants
+        .filter((participant) => participant.audioTrack)
+        .map((participant) => participant.identity)
+    );
+
+    micAnalyserRef.current.forEach((entry, participantId) => {
+      if (nextParticipantIds.has(participantId)) {
+        return;
+      }
+
+      entry.source.disconnect();
+      void entry.audioContext.close();
+      micAnalyserRef.current.delete(participantId);
+      speakerActivityRef.current.delete(participantId);
+    });
+
+    state.participants.forEach((participant) => {
+      const audioTrack = participant.audioTrack;
+      if (!audioTrack) {
+        return;
+      }
+
+      const existing = micAnalyserRef.current.get(participant.identity);
+      if (existing) {
+        return;
+      }
+
+      const AudioContextCtor = window.AudioContext ?? (window as typeof window & {
+        webkitAudioContext?: typeof AudioContext;
+      }).webkitAudioContext;
+
+      if (!AudioContextCtor) {
+        return;
+      }
+
+      try {
+        const audioContext = new AudioContextCtor();
+        const mediaStream = new MediaStream([audioTrack.mediaStreamTrack]);
+        const source = audioContext.createMediaStreamSource(mediaStream);
+        const analyser = audioContext.createAnalyser();
+        analyser.fftSize = 1024;
+        analyser.smoothingTimeConstant = 0.7;
+        source.connect(analyser);
+        void audioContext.resume().catch(() => {
+          // Best effort for browsers that require a user gesture.
+        });
+
+        micAnalyserRef.current.set(participant.identity, {
+          participantId: participant.identity,
+          audioContext,
+          analyser,
+          source,
+          data: new Uint8Array(analyser.fftSize),
+        });
+      } catch (error) {
+        console.warn("[RoomVoiceContext] Failed to initialize microphone analyser:", error);
+      }
+    });
+
+    const poll = window.setInterval(() => {
+      const now = Date.now();
+
+      micAnalyserRef.current.forEach((entry) => {
+        if (entry.audioContext.state === "suspended") {
+          void entry.audioContext.resume().catch(() => {
+            // Ignore and keep polling.
+          });
+          return;
+        }
+
+        entry.analyser.getByteTimeDomainData(entry.data);
+        const rms = calculateRms(entry.data);
+
+        if (rms > 0.02) {
+          speakerActivityRef.current.set(entry.participantId, now);
+        }
+      });
+    }, 150);
+
+    return () => window.clearInterval(poll);
+  }, [calculateRms, state.participants]);
+
+  useEffect(() => {
+    const nextParticipantIds = new Set(
+      state.participants
+        .filter((participant) => participant.screenShareAudioTrack)
+        .map((participant) => participant.identity)
+    );
+
+    screenShareAnalyserRef.current.forEach((entry, participantId) => {
+      if (nextParticipantIds.has(participantId)) {
+        return;
+      }
+
+      entry.source.disconnect();
+      void entry.audioContext.close();
+      screenShareAnalyserRef.current.delete(participantId);
+      screenShareActivityRef.current.delete(participantId);
+    });
+
+    state.participants.forEach((participant) => {
+      const screenShareAudioTrack = participant.screenShareAudioTrack;
+      if (!screenShareAudioTrack) {
+        return;
+      }
+
+      const existing = screenShareAnalyserRef.current.get(participant.identity);
+      if (existing) {
+        return;
+      }
+
+      const AudioContextCtor = window.AudioContext ?? (window as typeof window & {
+        webkitAudioContext?: typeof AudioContext;
+      }).webkitAudioContext;
+
+      if (!AudioContextCtor) {
+        return;
+      }
+
+      try {
+        const audioContext = new AudioContextCtor();
+        const mediaStream = new MediaStream([screenShareAudioTrack.mediaStreamTrack]);
+        const source = audioContext.createMediaStreamSource(mediaStream);
+        const analyser = audioContext.createAnalyser();
+        analyser.fftSize = 1024;
+        analyser.smoothingTimeConstant = 0.7;
+        source.connect(analyser);
+        void audioContext.resume().catch(() => {
+          // Best effort for browsers that require a user gesture.
+        });
+
+        screenShareAnalyserRef.current.set(participant.identity, {
+          participantId: participant.identity,
+          audioContext,
+          analyser,
+          source,
+          data: new Uint8Array(analyser.fftSize),
+        });
+      } catch (error) {
+        console.warn("[RoomVoiceContext] Failed to initialize screen-share analyser:", error);
+      }
+    });
+
+    const poll = window.setInterval(() => {
+      const now = Date.now();
+
+      screenShareAnalyserRef.current.forEach((entry) => {
+        if (entry.audioContext.state === "suspended") {
+          void entry.audioContext.resume().catch(() => {
+            // Ignore and keep polling.
+          });
+          return;
+        }
+
+        entry.analyser.getByteTimeDomainData(entry.data);
+        const rms = calculateRms(entry.data);
+
+        if (rms > 0.02) {
+          screenShareActivityRef.current.set(entry.participantId, now);
+        }
+      });
+    }, 150);
+
+    return () => window.clearInterval(poll);
+  }, [calculateRms, state.participants]);
+
   const resetState = useCallback((error: string | null = null) => {
+    speakerActivityRef.current.clear();
+    screenShareActivityRef.current.clear();
+    micAnalyserRef.current.forEach(({ source, audioContext }) => {
+      source.disconnect();
+      void audioContext.close();
+    });
+    micAnalyserRef.current.clear();
+    screenShareAnalyserRef.current.forEach(({ source, audioContext }) => {
+      source.disconnect();
+      void audioContext.close();
+    });
+    screenShareAnalyserRef.current.clear();
+
     setState({
       ...initialState,
       error,

--- a/src/pages/RoomPage.tsx
+++ b/src/pages/RoomPage.tsx
@@ -2,8 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import {
   ArrowLeft,
+  Maximize2,
   Mic,
   MicOff,
+  Minimize2,
   Monitor,
   MonitorOff,
   Users,
@@ -34,6 +36,23 @@ interface ControlButtonProps {
   label: string;
 }
 
+interface TileActionButtonProps {
+  label: string;
+  onClick: () => void;
+  icon?: React.ReactNode;
+}
+
+interface VisualTile {
+  id: string;
+  kind: "camera" | "screen-share";
+  participant: RoomVoiceParticipantState;
+  track: Track;
+}
+
+const getFullscreenToggleError = (error: unknown): string => {
+  return error instanceof Error ? error.message : "Failed to toggle fullscreen";
+};
+
 const ControlButton: React.FC<ControlButtonProps> = ({
   icon,
   activeIcon,
@@ -63,16 +82,55 @@ const ControlButton: React.FC<ControlButtonProps> = ({
   );
 };
 
+const TileActionButton: React.FC<TileActionButtonProps> = ({ label, onClick, icon }) => {
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+      className="inline-flex items-center gap-1 rounded-md bg-black/55 px-2 py-1 text-xs font-medium text-white transition-colors hover:bg-black/75"
+      title={label}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+};
+
 const VoiceTile: React.FC<{
   participant: RoomVoiceParticipantState;
   isCurrentUser: boolean;
   cameraTrack?: Track;
   audioTrack?: Track;
   isCameraOff?: boolean;
-}> = ({ participant, isCurrentUser, cameraTrack, audioTrack, isCameraOff = true }) => {
+  className?: string;
+  isFocused?: boolean;
+  canFocus?: boolean;
+  canFullscreen?: boolean;
+  onFocusToggle?: () => void;
+  onFullscreenError?: (message: string) => void;
+  onSelect?: () => void;
+}> = ({
+  participant,
+  isCurrentUser,
+  cameraTrack,
+  audioTrack,
+  isCameraOff = true,
+  className,
+  isFocused = false,
+  canFocus = false,
+  canFullscreen = false,
+  onFocusToggle,
+  onFullscreenError,
+  onSelect,
+}) => {
   const initials = (participant.name || participant.username || "?").slice(0, 1).toUpperCase();
+  const containerRef = useRef<HTMLDivElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const audioRef = useRef<HTMLAudioElement>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
   const hasVideoTrack = Boolean(cameraTrack);
   const showVideo = hasVideoTrack && !isCameraOff;
   const statusLabel = participant.is_screen_sharing
@@ -107,8 +165,50 @@ const VoiceTile: React.FC<{
     };
   }, [audioTrack, isCurrentUser]);
 
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(document.fullscreenElement === containerRef.current);
+    };
+
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () => document.removeEventListener("fullscreenchange", handleFullscreenChange);
+  }, []);
+
+  const handleFullscreen = useCallback(async () => {
+    if (!containerRef.current) {
+      return;
+    }
+
+    try {
+      if (document.fullscreenElement === containerRef.current) {
+        if (!document.exitFullscreen) {
+          onFullscreenError?.("Fullscreen exit is not available in this browser");
+          return;
+        }
+        await document.exitFullscreen();
+        return;
+      }
+
+      const requestFullscreen = containerRef.current.requestFullscreen?.bind(containerRef.current);
+      if (!requestFullscreen) {
+        onFullscreenError?.("Fullscreen is not available in this browser");
+        return;
+      }
+
+      await requestFullscreen();
+    } catch (error) {
+      onFullscreenError?.(getFullscreenToggleError(error));
+    }
+  }, [onFullscreenError]);
+
   return (
-    <div className="relative rounded-xl overflow-hidden bg-gray-800 aspect-video shadow-lg">
+    <div
+      ref={containerRef}
+      onClick={onSelect}
+      className={`relative overflow-hidden rounded-xl bg-gray-800 shadow-lg ${
+        className ?? "aspect-video"
+      } ${onSelect ? "cursor-pointer" : ""}`}
+    >
       {!isCurrentUser && <audio ref={audioRef} autoPlay playsInline />}
       {showVideo ? (
         <video
@@ -123,6 +223,31 @@ const VoiceTile: React.FC<{
           <div className="w-16 h-16 rounded-full bg-primary/30 flex items-center justify-center">
             <span className="text-2xl font-bold text-white">{initials}</span>
           </div>
+        </div>
+      )}
+
+      {showVideo && (canFocus || canFullscreen) && (
+        <div className="absolute left-3 top-3 z-10 flex items-center gap-2">
+          {canFocus && onFocusToggle && (
+            <TileActionButton
+              label={isFocused ? "Exit focus" : "Expand"}
+              onClick={onFocusToggle}
+              icon={isFocused ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
+            />
+          )}
+          {canFullscreen && (
+            <TileActionButton
+              label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+              onClick={() => void handleFullscreen()}
+              icon={
+                isFullscreen ? (
+                  <Minimize2 className="h-3.5 w-3.5" />
+                ) : (
+                  <Maximize2 className="h-3.5 w-3.5" />
+                )
+              }
+            />
+          )}
         </div>
       )}
 
@@ -160,8 +285,27 @@ const VoiceTile: React.FC<{
 const ScreenShareTile: React.FC<{
   participant: RoomVoiceParticipantState;
   screenShareTrack?: Track;
-}> = ({ participant, screenShareTrack }) => {
+  className?: string;
+  isFocused?: boolean;
+  canFocus?: boolean;
+  canFullscreen?: boolean;
+  onFocusToggle?: () => void;
+  onFullscreenError?: (message: string) => void;
+  onSelect?: () => void;
+}> = ({
+  participant,
+  screenShareTrack,
+  className,
+  isFocused = false,
+  canFocus = true,
+  canFullscreen = true,
+  onFocusToggle,
+  onFullscreenError,
+  onSelect,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   useEffect(() => {
     if (!videoRef.current || !screenShareTrack) {
@@ -176,12 +320,54 @@ const ScreenShareTile: React.FC<{
     };
   }, [screenShareTrack]);
 
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(document.fullscreenElement === containerRef.current);
+    };
+
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () => document.removeEventListener("fullscreenchange", handleFullscreenChange);
+  }, []);
+
   if (!screenShareTrack) {
     return null;
   }
 
+  const handleFullscreen = async () => {
+    if (!containerRef.current) {
+      return;
+    }
+
+    try {
+      if (document.fullscreenElement === containerRef.current) {
+        if (!document.exitFullscreen) {
+          onFullscreenError?.("Fullscreen exit is not available in this browser");
+          return;
+        }
+        await document.exitFullscreen();
+        return;
+      }
+
+      const requestFullscreen = containerRef.current.requestFullscreen?.bind(containerRef.current);
+      if (!requestFullscreen) {
+        onFullscreenError?.("Fullscreen is not available in this browser");
+        return;
+      }
+
+      await requestFullscreen();
+    } catch (error) {
+      onFullscreenError?.(getFullscreenToggleError(error));
+    }
+  };
+
   return (
-    <div className="relative rounded-xl overflow-hidden bg-gray-950 aspect-video shadow-lg ring-1 ring-blue-400/40">
+    <div
+      ref={containerRef}
+      onClick={onSelect}
+      className={`relative overflow-hidden rounded-xl bg-gray-950 shadow-lg ring-1 ring-blue-400/40 ${
+        className ?? "aspect-video"
+      } ${onSelect ? "cursor-pointer" : ""}`}
+    >
       <video
         ref={videoRef}
         autoPlay
@@ -189,6 +375,31 @@ const ScreenShareTile: React.FC<{
         muted
         className="w-full h-full object-contain bg-black"
       />
+
+      {(canFocus || canFullscreen) && (
+        <div className="absolute left-3 top-3 z-10 flex items-center gap-2">
+          {canFocus && onFocusToggle && (
+            <TileActionButton
+              label={isFocused ? "Exit focus" : "Expand"}
+              onClick={onFocusToggle}
+              icon={isFocused ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
+            />
+          )}
+          {canFullscreen && (
+            <TileActionButton
+              label={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+              onClick={() => void handleFullscreen()}
+              icon={
+                isFullscreen ? (
+                  <Minimize2 className="h-3.5 w-3.5" />
+                ) : (
+                  <Maximize2 className="h-3.5 w-3.5" />
+                )
+              }
+            />
+          )}
+        </div>
+      )}
 
       <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent p-3">
         <div className="flex items-center justify-between">
@@ -229,6 +440,7 @@ export default function RoomPage(): JSX.Element {
   const [isLoading, setIsLoading] = useState(true);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [focusedTileId, setFocusedTileId] = useState<string | null>(null);
 
   const getRoomDisplayName = useCallback(
     (rawName: string, membersList: RoomStateResponse["members"]) => {
@@ -363,8 +575,66 @@ export default function RoomPage(): JSX.Element {
         ),
     [displayedVoiceParticipants, liveParticipantsByUserId, localScreenShareTrack, user?.user_id]
   );
+  const visualTiles = useMemo<VisualTile[]>(
+    () => [
+      ...displayedVoiceParticipants.flatMap((participant) => {
+        const liveParticipant = liveParticipantsByUserId.get(participant.user_id);
+        const cameraTrack =
+          participant.user_id === user?.user_id
+            ? localVideoTrack ?? liveParticipant?.cameraTrack
+            : liveParticipant?.cameraTrack;
+
+        if (!cameraTrack || liveParticipant?.isCameraOff) {
+          return [];
+        }
+
+        return [{
+          id: `camera:${participant.user_id}`,
+          kind: "camera" as const,
+          participant,
+          track: cameraTrack,
+        }];
+      }),
+      ...screenShareTiles.map(({ participant, screenShareTrack }) => ({
+        id: `screen-share:${participant.user_id}`,
+        kind: "screen-share" as const,
+        participant,
+        track: screenShareTrack,
+      })),
+    ],
+    [displayedVoiceParticipants, liveParticipantsByUserId, localVideoTrack, screenShareTiles, user?.user_id]
+  );
+  const focusedTile = focusedTileId
+    ? visualTiles.find((tile) => tile.id === focusedTileId) ?? null
+    : null;
+  const focusStripTiles = focusedTile
+    ? [
+        ...displayedVoiceParticipants
+          .filter((participant) => `camera:${participant.user_id}` !== focusedTile.id)
+          .map((participant) => ({ kind: "participant" as const, participant })),
+        ...screenShareTiles
+          .filter(({ participant }) => `screen-share:${participant.user_id}` !== focusedTile.id)
+          .map(({ participant, screenShareTrack }) => ({
+            kind: "screen-share" as const,
+            participant,
+            screenShareTrack,
+          })),
+      ]
+    : [];
 
   const canToggleMedia = isCurrentRoomSession && roomVoiceState.status === "active" && !isSubmitting;
+
+  useEffect(() => {
+    if (!focusedTileId) {
+      return;
+    }
+
+    if (visualTiles.some((tile) => tile.id === focusedTileId)) {
+      return;
+    }
+
+    setFocusedTileId(visualTiles[0]?.id ?? null);
+  }, [focusedTileId, visualTiles]);
 
   const handleJoinVoice = async () => {
     if (!token || !roomIdentifier) return;
@@ -543,6 +813,110 @@ export default function RoomPage(): JSX.Element {
                   )}
                 </div>
               </div>
+            ) : focusedTile ? (
+              <div className="flex h-full min-h-0 flex-col gap-4">
+                <div className="min-h-0 flex-1">
+                  {focusedTile.kind === "camera" ? (
+                    <VoiceTile
+                      participant={focusedTile.participant}
+                      isCurrentUser={focusedTile.participant.user_id === user?.user_id}
+                      isCameraOff={false}
+                      cameraTrack={focusedTile.track}
+                      audioTrack={liveParticipantsByUserId.get(focusedTile.participant.user_id)?.audioTrack}
+                      className="h-full min-h-[22rem]"
+                      isFocused
+                      canFocus
+                      canFullscreen
+                      onFocusToggle={() => setFocusedTileId(null)}
+                      onFullscreenError={setError}
+                    />
+                  ) : (
+                    <ScreenShareTile
+                      participant={focusedTile.participant}
+                      screenShareTrack={focusedTile.track}
+                      className="h-full min-h-[22rem]"
+                      isFocused
+                      canFocus
+                      canFullscreen
+                      onFocusToggle={() => setFocusedTileId(null)}
+                      onFullscreenError={setError}
+                    />
+                  )}
+                </div>
+
+                <div className="shrink-0">
+                  <div className="mb-2 flex items-center justify-between">
+                    <p className="text-sm font-medium text-white/80">Other tiles</p>
+                    <button
+                      type="button"
+                      onClick={() => setFocusedTileId(null)}
+                      className="rounded-md bg-gray-800 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-gray-700"
+                    >
+                      Exit focus
+                    </button>
+                  </div>
+                  <div className="flex gap-3 overflow-x-auto pb-2">
+                    {focusStripTiles.map((tile) => {
+                      if (tile.kind === "participant") {
+                        const liveParticipant = liveParticipantsByUserId.get(tile.participant.user_id);
+                        return (
+                          <div key={`participant-strip:${tile.participant.user_id}`} className="w-72 shrink-0">
+                            <VoiceTile
+                              participant={tile.participant}
+                              isCurrentUser={tile.participant.user_id === user?.user_id}
+                              isCameraOff={liveParticipant?.isCameraOff}
+                              cameraTrack={
+                                tile.participant.user_id === user?.user_id
+                                  ? localVideoTrack ?? liveParticipant?.cameraTrack
+                                  : liveParticipant?.cameraTrack
+                              }
+                              audioTrack={liveParticipant?.audioTrack}
+                              className="aspect-video"
+                              canFocus={Boolean(
+                                (tile.participant.user_id === user?.user_id
+                                  ? localVideoTrack ?? liveParticipant?.cameraTrack
+                                  : liveParticipant?.cameraTrack) && !liveParticipant?.isCameraOff
+                              )}
+                              canFullscreen={Boolean(
+                                (tile.participant.user_id === user?.user_id
+                                  ? localVideoTrack ?? liveParticipant?.cameraTrack
+                                  : liveParticipant?.cameraTrack) && !liveParticipant?.isCameraOff
+                              )}
+                              onFocusToggle={() => setFocusedTileId(`camera:${tile.participant.user_id}`)}
+                              onSelect={
+                                (tile.participant.user_id === user?.user_id
+                                  ? localVideoTrack ?? liveParticipant?.cameraTrack
+                                  : liveParticipant?.cameraTrack) && !liveParticipant?.isCameraOff
+                                  ? () => setFocusedTileId(`camera:${tile.participant.user_id}`)
+                                  : undefined
+                              }
+                              onFullscreenError={setError}
+                            />
+                          </div>
+                        );
+                      }
+
+                      return (
+                        <div
+                          key={`screen-share-strip:${tile.participant.user_id}`}
+                          className="w-72 shrink-0"
+                        >
+                          <ScreenShareTile
+                            participant={tile.participant}
+                            screenShareTrack={tile.screenShareTrack}
+                            className="aspect-video"
+                            canFocus
+                            canFullscreen
+                            onFocusToggle={() => setFocusedTileId(`screen-share:${tile.participant.user_id}`)}
+                            onSelect={() => setFocusedTileId(`screen-share:${tile.participant.user_id}`)}
+                            onFullscreenError={setError}
+                          />
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
             ) : (
               <div className={`grid ${getGridClass()} gap-4 h-full`}>
                 {displayedVoiceParticipants.map((participant) => (
@@ -557,6 +931,28 @@ export default function RoomPage(): JSX.Element {
                         : liveParticipantsByUserId.get(participant.user_id)?.cameraTrack
                     }
                     audioTrack={liveParticipantsByUserId.get(participant.user_id)?.audioTrack}
+                    canFocus={Boolean(
+                      (participant.user_id === user?.user_id
+                        ? localVideoTrack ?? liveParticipantsByUserId.get(participant.user_id)?.cameraTrack
+                        : liveParticipantsByUserId.get(participant.user_id)?.cameraTrack) &&
+                        !liveParticipantsByUserId.get(participant.user_id)?.isCameraOff
+                    )}
+                    canFullscreen={Boolean(
+                      (participant.user_id === user?.user_id
+                        ? localVideoTrack ?? liveParticipantsByUserId.get(participant.user_id)?.cameraTrack
+                        : liveParticipantsByUserId.get(participant.user_id)?.cameraTrack) &&
+                        !liveParticipantsByUserId.get(participant.user_id)?.isCameraOff
+                    )}
+                    onFocusToggle={() => setFocusedTileId(`camera:${participant.user_id}`)}
+                    onSelect={
+                      (participant.user_id === user?.user_id
+                        ? localVideoTrack ?? liveParticipantsByUserId.get(participant.user_id)?.cameraTrack
+                        : liveParticipantsByUserId.get(participant.user_id)?.cameraTrack) &&
+                        !liveParticipantsByUserId.get(participant.user_id)?.isCameraOff
+                        ? () => setFocusedTileId(`camera:${participant.user_id}`)
+                        : undefined
+                    }
+                    onFullscreenError={setError}
                   />
                 ))}
                 {screenShareTiles.map(({ participant, screenShareTrack }) => (
@@ -564,6 +960,11 @@ export default function RoomPage(): JSX.Element {
                     key={`${participant.user_id}-screen-share`}
                     participant={participant}
                     screenShareTrack={screenShareTrack}
+                    canFocus
+                    canFullscreen
+                    onFocusToggle={() => setFocusedTileId(`screen-share:${participant.user_id}`)}
+                    onSelect={() => setFocusedTileId(`screen-share:${participant.user_id}`)}
+                    onFullscreenError={setError}
                   />
                 ))}
               </div>

--- a/src/pages/RoomPage.tsx
+++ b/src/pages/RoomPage.tsx
@@ -53,6 +53,20 @@ const getFullscreenToggleError = (error: unknown): string => {
   return error instanceof Error ? error.message : "Failed to toggle fullscreen";
 };
 
+const getSpeakingTileClasses = (isSpeaking: boolean): string => {
+  return isSpeaking
+    ? "ring-4 ring-emerald-400 border-2 border-emerald-300 shadow-[0_0_0_2px_rgba(52,211,153,0.75),0_0_28px_rgba(52,211,153,0.45)]"
+    : "";
+};
+
+const isParticipantHighlighted = (
+  participant: RoomVoiceParticipantState,
+  liveIdentity: string | undefined,
+  activeIds: Set<string>
+): boolean => {
+  return activeIds.has(participant.user_id) || activeIds.has(participant.username) || Boolean(liveIdentity && activeIds.has(liveIdentity));
+};
+
 const ControlButton: React.FC<ControlButtonProps> = ({
   icon,
   activeIcon,
@@ -109,6 +123,7 @@ const VoiceTile: React.FC<{
   isFocused?: boolean;
   canFocus?: boolean;
   canFullscreen?: boolean;
+  isSpeaking?: boolean;
   onFocusToggle?: () => void;
   onFullscreenError?: (message: string) => void;
   onSelect?: () => void;
@@ -122,6 +137,7 @@ const VoiceTile: React.FC<{
   isFocused = false,
   canFocus = false,
   canFullscreen = false,
+  isSpeaking = false,
   onFocusToggle,
   onFullscreenError,
   onSelect,
@@ -205,7 +221,7 @@ const VoiceTile: React.FC<{
     <div
       ref={containerRef}
       onClick={onSelect}
-      className={`relative overflow-hidden rounded-xl bg-gray-800 shadow-lg ${
+      className={`relative overflow-hidden rounded-xl bg-gray-800 shadow-lg ${getSpeakingTileClasses(isSpeaking)} ${
         className ?? "aspect-video"
       } ${onSelect ? "cursor-pointer" : ""}`}
     >
@@ -289,6 +305,7 @@ const ScreenShareTile: React.FC<{
   isFocused?: boolean;
   canFocus?: boolean;
   canFullscreen?: boolean;
+  isSpeaking?: boolean;
   onFocusToggle?: () => void;
   onFullscreenError?: (message: string) => void;
   onSelect?: () => void;
@@ -299,6 +316,7 @@ const ScreenShareTile: React.FC<{
   isFocused = false,
   canFocus = true,
   canFullscreen = true,
+  isSpeaking = false,
   onFocusToggle,
   onFullscreenError,
   onSelect,
@@ -364,7 +382,7 @@ const ScreenShareTile: React.FC<{
     <div
       ref={containerRef}
       onClick={onSelect}
-      className={`relative overflow-hidden rounded-xl bg-gray-950 shadow-lg ring-1 ring-blue-400/40 ${
+      className={`relative overflow-hidden rounded-xl bg-gray-950 shadow-lg ring-1 ring-blue-400/40 ${getSpeakingTileClasses(isSpeaking)} ${
         className ?? "aspect-video"
       } ${onSelect ? "cursor-pointer" : ""}`}
     >
@@ -607,6 +625,8 @@ export default function RoomPage(): JSX.Element {
   const focusedTile = focusedTileId
     ? visualTiles.find((tile) => tile.id === focusedTileId) ?? null
     : null;
+  const activeSpeakerIds = new Set(roomVoiceState.activeSpeakerIds);
+  const activeScreenShareSpeakerIds = new Set(roomVoiceState.activeScreenShareSpeakerIds);
   const focusStripTiles = focusedTile
     ? [
         ...displayedVoiceParticipants
@@ -827,6 +847,11 @@ export default function RoomPage(): JSX.Element {
                       isFocused
                       canFocus
                       canFullscreen
+                      isSpeaking={isParticipantHighlighted(
+                        focusedTile.participant,
+                        liveParticipantsByUserId.get(focusedTile.participant.user_id)?.identity,
+                        activeSpeakerIds
+                      )}
                       onFocusToggle={() => setFocusedTileId(null)}
                       onFullscreenError={setError}
                     />
@@ -838,6 +863,11 @@ export default function RoomPage(): JSX.Element {
                       isFocused
                       canFocus
                       canFullscreen
+                      isSpeaking={isParticipantHighlighted(
+                        focusedTile.participant,
+                        liveParticipantsByUserId.get(focusedTile.participant.user_id)?.identity,
+                        activeScreenShareSpeakerIds
+                      )}
                       onFocusToggle={() => setFocusedTileId(null)}
                       onFullscreenError={setError}
                     />
@@ -859,6 +889,11 @@ export default function RoomPage(): JSX.Element {
                     {focusStripTiles.map((tile) => {
                       if (tile.kind === "participant") {
                         const liveParticipant = liveParticipantsByUserId.get(tile.participant.user_id);
+                        const isSpeaking = isParticipantHighlighted(
+                          tile.participant,
+                          liveParticipant?.identity,
+                          activeSpeakerIds
+                        );
                         return (
                           <div key={`participant-strip:${tile.participant.user_id}`} className="w-72 shrink-0">
                             <VoiceTile
@@ -872,6 +907,7 @@ export default function RoomPage(): JSX.Element {
                               }
                               audioTrack={liveParticipant?.audioTrack}
                               className="aspect-video"
+                              isSpeaking={isSpeaking}
                               canFocus={Boolean(
                                 (tile.participant.user_id === user?.user_id
                                   ? localVideoTrack ?? liveParticipant?.cameraTrack
@@ -907,6 +943,11 @@ export default function RoomPage(): JSX.Element {
                             className="aspect-video"
                             canFocus
                             canFullscreen
+                            isSpeaking={isParticipantHighlighted(
+                              tile.participant,
+                              liveParticipantsByUserId.get(tile.participant.user_id)?.identity,
+                              activeScreenShareSpeakerIds
+                            )}
                             onFocusToggle={() => setFocusedTileId(`screen-share:${tile.participant.user_id}`)}
                             onSelect={() => setFocusedTileId(`screen-share:${tile.participant.user_id}`)}
                             onFullscreenError={setError}
@@ -931,6 +972,11 @@ export default function RoomPage(): JSX.Element {
                         : liveParticipantsByUserId.get(participant.user_id)?.cameraTrack
                     }
                     audioTrack={liveParticipantsByUserId.get(participant.user_id)?.audioTrack}
+                    isSpeaking={isParticipantHighlighted(
+                      participant,
+                      liveParticipantsByUserId.get(participant.user_id)?.identity,
+                      activeSpeakerIds
+                    )}
                     canFocus={Boolean(
                       (participant.user_id === user?.user_id
                         ? localVideoTrack ?? liveParticipantsByUserId.get(participant.user_id)?.cameraTrack
@@ -960,6 +1006,11 @@ export default function RoomPage(): JSX.Element {
                     key={`${participant.user_id}-screen-share`}
                     participant={participant}
                     screenShareTrack={screenShareTrack}
+                    isSpeaking={isParticipantHighlighted(
+                      participant,
+                      liveParticipantsByUserId.get(participant.user_id)?.identity,
+                      activeScreenShareSpeakerIds
+                    )}
                     canFocus
                     canFullscreen
                     onFocusToggle={() => setFocusedTileId(`screen-share:${participant.user_id}`)}

--- a/src/pages/RoomPage.tsx
+++ b/src/pages/RoomPage.tsx
@@ -590,13 +590,18 @@ export default function RoomPage(): JSX.Element {
       displayedVoiceParticipants
         .map((participant) => {
           const liveParticipant = liveParticipantsByUserId.get(participant.user_id);
+          const isLocalParticipant = participant.user_id === user?.user_id;
+          const isActivelySharing =
+            isLocalParticipant && isCurrentRoomSession
+              ? roomVoiceState.screenSharing
+              : participant.is_screen_sharing;
           const screenShareTrack =
-            participant.user_id === user?.user_id
+            isLocalParticipant
               ? localScreenShareTrack ?? liveParticipant?.screenShareTrack
               : liveParticipant?.screenShareTrack;
           const screenShareAudioTrack = liveParticipant?.screenShareAudioTrack;
 
-          if (!screenShareTrack) {
+          if (!isActivelySharing || !screenShareTrack) {
             return null;
           }
 
@@ -615,7 +620,14 @@ export default function RoomPage(): JSX.Element {
             screenShareAudioTrack: Track | undefined;
           } => tile !== null
         ),
-    [displayedVoiceParticipants, liveParticipantsByUserId, localScreenShareTrack, user?.user_id]
+    [
+      displayedVoiceParticipants,
+      isCurrentRoomSession,
+      liveParticipantsByUserId,
+      localScreenShareTrack,
+      roomVoiceState.screenSharing,
+      user?.user_id,
+    ]
   );
   const visualTiles = useMemo<VisualTile[]>(
     () => [
@@ -1129,18 +1141,18 @@ export default function RoomPage(): JSX.Element {
             className="flex items-center justify-center gap-4 p-4 bg-gray-800 border-t border-gray-700"
           >
             <ControlButton
-              icon={<MicOff className="w-5 h-5 text-red-400" />}
-              activeIcon={<Mic className="w-5 h-5 text-white" />}
-              isActive={isCurrentRoomSession ? roomVoiceState.localMuted : !myVoiceState?.is_mic_enabled}
+              icon={<Mic className="w-5 h-5 text-white" />}
+              activeIcon={<MicOff className="w-5 h-5 text-red-400" />}
+              isActive={isCurrentRoomSession ? !roomVoiceState.localMuted : Boolean(myVoiceState?.is_mic_enabled)}
               disabled={!canToggleMedia}
               onClick={() => void handleToggleMic()}
               label={isCurrentRoomSession && roomVoiceState.localMuted ? "Unmute" : "Mute"}
             />
 
             <ControlButton
-              icon={<VideoOff className="w-5 h-5 text-red-400" />}
-              activeIcon={<Video className="w-5 h-5 text-white" />}
-              isActive={isCurrentRoomSession ? roomVoiceState.localCameraOff : !myVoiceState?.is_camera_enabled}
+              icon={<Video className="w-5 h-5 text-white" />}
+              activeIcon={<VideoOff className="w-5 h-5 text-red-400" />}
+              isActive={isCurrentRoomSession ? !roomVoiceState.localCameraOff : Boolean(myVoiceState?.is_camera_enabled)}
               disabled={!canToggleMedia}
               onClick={() => void handleToggleCamera()}
               label={
@@ -1151,9 +1163,9 @@ export default function RoomPage(): JSX.Element {
             />
 
             <ControlButton
-              icon={<MonitorOff className="w-5 h-5 text-red-400" />}
-              activeIcon={<Monitor className="w-5 h-5 text-white" />}
-              isActive={!(isCurrentRoomSession ? roomVoiceState.screenSharing : Boolean(myVoiceState?.is_screen_sharing))}
+              icon={<Monitor className="w-5 h-5 text-white" />}
+              activeIcon={<MonitorOff className="w-5 h-5 text-red-400" />}
+              isActive={isCurrentRoomSession ? roomVoiceState.screenSharing : Boolean(myVoiceState?.is_screen_sharing)}
               disabled={!canToggleMedia}
               onClick={() => void handleToggleScreenShare()}
               label={

--- a/src/pages/RoomPage.tsx
+++ b/src/pages/RoomPage.tsx
@@ -47,6 +47,7 @@ interface VisualTile {
   kind: "camera" | "screen-share";
   participant: RoomVoiceParticipantState;
   track: Track;
+  audioTrack?: Track;
 }
 
 const getFullscreenToggleError = (error: unknown): string => {
@@ -301,6 +302,8 @@ const VoiceTile: React.FC<{
 const ScreenShareTile: React.FC<{
   participant: RoomVoiceParticipantState;
   screenShareTrack?: Track;
+  screenShareAudioTrack?: Track;
+  isCurrentUser?: boolean;
   className?: string;
   isFocused?: boolean;
   canFocus?: boolean;
@@ -312,6 +315,8 @@ const ScreenShareTile: React.FC<{
 }> = ({
   participant,
   screenShareTrack,
+  screenShareAudioTrack,
+  isCurrentUser = false,
   className,
   isFocused = false,
   canFocus = true,
@@ -323,6 +328,7 @@ const ScreenShareTile: React.FC<{
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
+  const audioRef = useRef<HTMLAudioElement>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
 
   useEffect(() => {
@@ -337,6 +343,19 @@ const ScreenShareTile: React.FC<{
       track.detach(videoRef.current!);
     };
   }, [screenShareTrack]);
+
+  useEffect(() => {
+    if (isCurrentUser || !audioRef.current || !screenShareAudioTrack) {
+      return undefined;
+    }
+
+    const track = screenShareAudioTrack as AudioTrack;
+    track.attach(audioRef.current);
+
+    return () => {
+      track.detach(audioRef.current!);
+    };
+  }, [screenShareAudioTrack, isCurrentUser]);
 
   useEffect(() => {
     const handleFullscreenChange = () => {
@@ -393,6 +412,7 @@ const ScreenShareTile: React.FC<{
         muted
         className="w-full h-full object-contain bg-black"
       />
+      {!isCurrentUser && <audio ref={audioRef} autoPlay />}
 
       {(canFocus || canFullscreen) && (
         <div className="absolute left-3 top-3 z-10 flex items-center gap-2">
@@ -573,6 +593,7 @@ export default function RoomPage(): JSX.Element {
             participant.user_id === user?.user_id
               ? localScreenShareTrack ?? liveParticipant?.screenShareTrack
               : liveParticipant?.screenShareTrack;
+          const screenShareAudioTrack = liveParticipant?.screenShareAudioTrack;
 
           if (!screenShareTrack) {
             return null;
@@ -581,6 +602,7 @@ export default function RoomPage(): JSX.Element {
           return {
             participant,
             screenShareTrack,
+            screenShareAudioTrack,
           };
         })
         .filter(
@@ -589,6 +611,7 @@ export default function RoomPage(): JSX.Element {
           ): tile is {
             participant: RoomVoiceParticipantState;
             screenShareTrack: Track;
+            screenShareAudioTrack: Track | undefined;
           } => tile !== null
         ),
     [displayedVoiceParticipants, liveParticipantsByUserId, localScreenShareTrack, user?.user_id]
@@ -613,11 +636,12 @@ export default function RoomPage(): JSX.Element {
           track: cameraTrack,
         }];
       }),
-      ...screenShareTiles.map(({ participant, screenShareTrack }) => ({
+      ...screenShareTiles.map(({ participant, screenShareTrack, screenShareAudioTrack }) => ({
         id: `screen-share:${participant.user_id}`,
         kind: "screen-share" as const,
         participant,
         track: screenShareTrack,
+        audioTrack: screenShareAudioTrack,
       })),
     ],
     [displayedVoiceParticipants, liveParticipantsByUserId, localVideoTrack, screenShareTiles, user?.user_id]
@@ -634,10 +658,11 @@ export default function RoomPage(): JSX.Element {
           .map((participant) => ({ kind: "participant" as const, participant })),
         ...screenShareTiles
           .filter(({ participant }) => `screen-share:${participant.user_id}` !== focusedTile.id)
-          .map(({ participant, screenShareTrack }) => ({
+          .map(({ participant, screenShareTrack, screenShareAudioTrack }) => ({
             kind: "screen-share" as const,
             participant,
             screenShareTrack,
+            screenShareAudioTrack,
           })),
       ]
     : [];
@@ -859,6 +884,8 @@ export default function RoomPage(): JSX.Element {
                     <ScreenShareTile
                       participant={focusedTile.participant}
                       screenShareTrack={focusedTile.track}
+                      screenShareAudioTrack={focusedTile.audioTrack}
+                      isCurrentUser={focusedTile.participant.user_id === user?.user_id}
                       className="h-full min-h-[22rem]"
                       isFocused
                       canFocus
@@ -940,6 +967,8 @@ export default function RoomPage(): JSX.Element {
                           <ScreenShareTile
                             participant={tile.participant}
                             screenShareTrack={tile.screenShareTrack}
+                            screenShareAudioTrack={tile.screenShareAudioTrack}
+                            isCurrentUser={tile.participant.user_id === user?.user_id}
                             className="aspect-video"
                             canFocus
                             canFullscreen
@@ -1001,11 +1030,13 @@ export default function RoomPage(): JSX.Element {
                     onFullscreenError={setError}
                   />
                 ))}
-                {screenShareTiles.map(({ participant, screenShareTrack }) => (
+                {screenShareTiles.map(({ participant, screenShareTrack, screenShareAudioTrack }) => (
                   <ScreenShareTile
                     key={`${participant.user_id}-screen-share`}
                     participant={participant}
                     screenShareTrack={screenShareTrack}
+                    screenShareAudioTrack={screenShareAudioTrack}
+                    isCurrentUser={participant.user_id === user?.user_id}
                     isSpeaking={isParticipantHighlighted(
                       participant,
                       liveParticipantsByUserId.get(participant.user_id)?.identity,

--- a/src/pages/RoomPage.tsx
+++ b/src/pages/RoomPage.tsx
@@ -479,6 +479,7 @@ export default function RoomPage(): JSX.Element {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [focusedTileId, setFocusedTileId] = useState<string | null>(null);
+  const autoRejoinAttemptRef = useRef<string | null>(null);
 
   const getRoomDisplayName = useCallback(
     (rawName: string, membersList: RoomStateResponse["members"]) => {
@@ -668,6 +669,52 @@ export default function RoomPage(): JSX.Element {
     : [];
 
   const canToggleMedia = isCurrentRoomSession && roomVoiceState.status === "active" && !isSubmitting;
+
+  useEffect(() => {
+    if (
+      !roomState?.in_voice ||
+      !token ||
+      !roomIdentifier ||
+      isCurrentRoomSession ||
+      roomVoiceState.status !== "idle" ||
+      autoRejoinAttemptRef.current === roomIdentifier
+    ) {
+      return undefined;
+    }
+
+    let cancelled = false;
+    autoRejoinAttemptRef.current = roomIdentifier;
+
+    const reconnectVoice = async () => {
+      try {
+        await joinRoomVoiceSession(roomIdentifier, roomName || routeRoomName || roomIdentifier);
+        if (!cancelled) {
+          await loadRoomState();
+        }
+      } catch (err) {
+        if (!cancelled) {
+          autoRejoinAttemptRef.current = null;
+          setError(err instanceof Error ? err.message : "Failed to reconnect room voice");
+        }
+      }
+    };
+
+    void reconnectVoice();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    isCurrentRoomSession,
+    joinRoomVoiceSession,
+    loadRoomState,
+    roomIdentifier,
+    roomName,
+    roomState?.in_voice,
+    roomVoiceState.status,
+    routeRoomName,
+    token,
+  ]);
 
   useEffect(() => {
     if (!focusedTileId) {

--- a/src/services/livekit.ts
+++ b/src/services/livekit.ts
@@ -93,6 +93,7 @@ export class LiveKitClient {
   private localVideoTrack: LocalVideoTrack | null = null;
   private localAudioTrack: LocalAudioTrack | null = null;
   private screenShareTrack: LocalVideoTrack | null = null;
+  private screenShareAudioTrack: LocalAudioTrack | null = null;
   private isMicMuted = false;
   private isCameraMuted = false;
   private isScreenSharing = false;
@@ -401,12 +402,24 @@ export class LiveKitClient {
 
     try {
       this.ensureMediaDevicesAvailable('screen share');
-      const publication = await this.room.localParticipant.setScreenShareEnabled(true);
+      const publication = await this.room.localParticipant.setScreenShareEnabled(true, {
+        audio: {
+          autoGainControl: false,
+          echoCancellation: false,
+          noiseSuppression: false,
+        },
+        systemAudio: 'include',
+        surfaceSwitching: 'include',
+        suppressLocalAudioPlayback: false,
+      });
       const publicationTrack = publication?.track as LocalVideoTrack | undefined;
       const fallbackTrack = this.room.localParticipant.getTrackPublication(Track.Source.ScreenShare)
         ?.track as LocalVideoTrack | undefined;
+      const screenAudioTrack = this.room.localParticipant.getTrackPublication(Track.Source.ScreenShareAudio)
+        ?.track as LocalAudioTrack | undefined;
 
       this.screenShareTrack = publicationTrack || fallbackTrack || null;
+      this.screenShareAudioTrack = screenAudioTrack || null;
       this.isScreenSharing = true;
       this.handlers.onScreenShareStarted?.();
     } catch (err) {
@@ -422,6 +435,7 @@ export class LiveKitClient {
 
     await this.room.localParticipant.setScreenShareEnabled(false);
     this.screenShareTrack = null;
+    this.screenShareAudioTrack = null;
     this.isScreenSharing = false;
     this.handlers.onScreenShareStopped?.();
   }
@@ -508,6 +522,17 @@ export class LiveKitClient {
       ?.track as LocalVideoTrack | undefined;
 
     return screenTrack || this.screenShareTrack;
+  }
+
+  getScreenShareAudioTrack(): LocalAudioTrack | null {
+    if (!this.room) {
+      return this.screenShareAudioTrack;
+    }
+
+    const screenAudioTrack = this.room.localParticipant.getTrackPublication(Track.Source.ScreenShareAudio)
+      ?.track as LocalAudioTrack | undefined;
+
+    return screenAudioTrack || this.screenShareAudioTrack;
   }
 
   isMicEnabled(): boolean {

--- a/src/services/livekit.ts
+++ b/src/services/livekit.ts
@@ -96,8 +96,8 @@ export class LiveKitClient {
   private screenShareTrack: LocalVideoTrack | null = null;
   private screenShareAudioTrack: LocalAudioTrack | null = null;
   private screenShareStopCleanup: (() => void) | null = null;
-  private isMicMuted = false;
-  private isCameraMuted = false;
+  private isMicMuted = true;
+  private isCameraMuted = true;
   private isScreenSharing = false;
 
   private ensureMediaDevicesAvailable(feature: 'microphone' | 'camera' | 'screen share'): void {
@@ -595,15 +595,15 @@ export class LiveKitClient {
   }
 
   isMicEnabled(): boolean {
-    return !this.isMicMuted;
+    return Boolean(this.getLocalAudioTrack()) && !this.isMicMuted;
   }
 
   isCameraEnabled(): boolean {
-    return !this.isCameraMuted;
+    return Boolean(this.getLocalVideoTrack()) && !this.isCameraMuted;
   }
 
   isScreenShareEnabled(): boolean {
-    return this.isScreenSharing;
+    return Boolean(this.getScreenShareTrack()) && this.isScreenSharing;
   }
 
   isConnected(): boolean {

--- a/src/services/livekit.ts
+++ b/src/services/livekit.ts
@@ -7,6 +7,7 @@ import {
   Room,
   RoomEvent,
   Track,
+  TrackEvent,
   TrackPublication,
   LocalTrack,
   RemoteTrack,
@@ -94,6 +95,7 @@ export class LiveKitClient {
   private localAudioTrack: LocalAudioTrack | null = null;
   private screenShareTrack: LocalVideoTrack | null = null;
   private screenShareAudioTrack: LocalAudioTrack | null = null;
+  private screenShareStopCleanup: (() => void) | null = null;
   private isMicMuted = false;
   private isCameraMuted = false;
   private isScreenSharing = false;
@@ -222,6 +224,12 @@ export class LiveKitClient {
     });
 
     this.room.on(RoomEvent.LocalTrackUnpublished, (publication, participant) => {
+      if (publication.source === Track.Source.ScreenShare) {
+        this.clearScreenShareState(true);
+      } else if (publication.source === Track.Source.ScreenShareAudio) {
+        this.screenShareAudioTrack = null;
+      }
+
       if (publication.track) {
         const trackInfo = this.createTrackInfo(publication.track, participant, true);
         this.handlers.onLocalTrackUnpublished?.(trackInfo);
@@ -311,6 +319,54 @@ export class LiveKitClient {
   private handleError(error: Error): void {
     console.error('LiveKit error:', error);
     this.handlers.onError?.(error);
+  }
+
+  private clearScreenShareState(notify: boolean): void {
+    const wasScreenSharing =
+      this.isScreenSharing || Boolean(this.screenShareTrack) || Boolean(this.screenShareAudioTrack);
+
+    if (this.screenShareStopCleanup) {
+      this.screenShareStopCleanup();
+      this.screenShareStopCleanup = null;
+    }
+
+    this.screenShareTrack = null;
+    this.screenShareAudioTrack = null;
+    this.isScreenSharing = false;
+
+    if (notify && wasScreenSharing) {
+      this.handlers.onScreenShareStopped?.();
+    }
+  }
+
+  private bindScreenShareEndedListeners(
+    videoTrack: LocalVideoTrack | null,
+    audioTrack: LocalAudioTrack | null
+  ): void {
+    if (this.screenShareStopCleanup) {
+      this.screenShareStopCleanup();
+      this.screenShareStopCleanup = null;
+    }
+
+    const handleEnded = () => {
+      this.clearScreenShareState(true);
+    };
+
+    const tracks = [videoTrack, audioTrack].filter(
+      (track): track is LocalVideoTrack | LocalAudioTrack => Boolean(track)
+    );
+
+    tracks.forEach((track) => {
+      track.on(TrackEvent.Ended, handleEnded);
+      track.mediaStreamTrack.addEventListener('ended', handleEnded);
+    });
+
+    this.screenShareStopCleanup = () => {
+      tracks.forEach((track) => {
+        track.off(TrackEvent.Ended, handleEnded);
+        track.mediaStreamTrack.removeEventListener('ended', handleEnded);
+      });
+    };
   }
 
   // === Media Controls ===
@@ -420,6 +476,7 @@ export class LiveKitClient {
 
       this.screenShareTrack = publicationTrack || fallbackTrack || null;
       this.screenShareAudioTrack = screenAudioTrack || null;
+      this.bindScreenShareEndedListeners(this.screenShareTrack, this.screenShareAudioTrack);
       this.isScreenSharing = true;
       this.handlers.onScreenShareStarted?.();
     } catch (err) {
@@ -429,15 +486,17 @@ export class LiveKitClient {
   }
 
   async stopScreenShare(): Promise<void> {
-    if (!this.room || !this.isScreenSharing) {
+    if (!this.room) {
+      this.clearScreenShareState(false);
+      return;
+    }
+
+    if (!this.isScreenSharing && !this.screenShareTrack && !this.screenShareAudioTrack) {
       return;
     }
 
     await this.room.localParticipant.setScreenShareEnabled(false);
-    this.screenShareTrack = null;
-    this.screenShareAudioTrack = null;
-    this.isScreenSharing = false;
-    this.handlers.onScreenShareStopped?.();
+    this.clearScreenShareState(true);
   }
 
   async toggleScreenShare(): Promise<boolean> {

--- a/src/services/livekit.ts
+++ b/src/services/livekit.ts
@@ -7,6 +7,7 @@ import {
   Room,
   RoomEvent,
   Track,
+  TrackPublication,
   LocalTrack,
   RemoteTrack,
   RemoteParticipant,
@@ -42,6 +43,7 @@ export interface ParticipantInfo {
   cameraTrack?: Track;
   screenShareTrack?: Track;
   audioTrack?: Track;
+  screenShareAudioTrack?: Track;
   isMuted: boolean;
   isCameraOff: boolean;
   isScreenSharing: boolean;
@@ -70,6 +72,7 @@ export interface LiveKitEventHandlers {
   // Participant events
   onParticipantConnected?: (participant: ParticipantInfo) => void;
   onParticipantDisconnected?: (participant: ParticipantInfo) => void;
+  onActiveSpeakersChanged?: (participantIdentities: string[]) => void;
 
   // Media state
   onMicMuted?: (muted: boolean) => void;
@@ -173,6 +176,10 @@ export class LiveKitClient {
       this.handlers.onDisconnected?.();
     });
 
+    this.room.on(RoomEvent.ActiveSpeakersChanged, (participants) => {
+      this.handlers.onActiveSpeakersChanged?.(participants.map((participant) => participant.identity));
+    });
+
     // Track events
     this.room.on(RoomEvent.TrackSubscribed, (track, _publication, participant) => {
       const trackInfo = this.createTrackInfo(track, participant, false);
@@ -265,10 +272,12 @@ export class LiveKitClient {
     isLocal: boolean
   ): ParticipantInfo {
     const screenSharePublication = participant.getTrackPublication(Track.Source.ScreenShare);
+    const screenShareAudioPublication = participant.getTrackPublication(Track.Source.ScreenShareAudio);
     const cameraPublication = participant.getTrackPublication(Track.Source.Camera);
-    const screenShareTrack = screenSharePublication?.track;
-    const cameraTrack = cameraPublication?.track;
-    const audioTrack = participant.getTrackPublication(Track.Source.Microphone)?.track;
+    const screenShareTrack = this.getLiveTrack(screenSharePublication);
+    const screenShareAudioTrack = this.getLiveTrack(screenShareAudioPublication);
+    const cameraTrack = this.getLiveTrack(cameraPublication);
+    const audioTrack = this.getLiveTrack(participant.getTrackPublication(Track.Source.Microphone));
 
     return {
       sid: participant.sid,
@@ -278,10 +287,24 @@ export class LiveKitClient {
       cameraTrack: cameraTrack || undefined,
       screenShareTrack: screenShareTrack || undefined,
       audioTrack: audioTrack || undefined,
+      screenShareAudioTrack: screenShareAudioTrack || undefined,
       isMuted: participant.getTrackPublication(Track.Source.Microphone)?.isMuted ?? true,
       isCameraOff: cameraPublication?.isMuted ?? true,
       isScreenSharing: !(screenSharePublication?.isMuted ?? true) && Boolean(screenShareTrack),
     };
+  }
+
+  private getLiveTrack(publication?: TrackPublication): Track | undefined {
+    const track = publication?.track;
+    if (!track) {
+      return undefined;
+    }
+
+    if (track.mediaStreamTrack.readyState !== 'live') {
+      return undefined;
+    }
+
+    return track;
   }
 
   private handleError(error: Error): void {

--- a/src/services/rooms-api.ts
+++ b/src/services/rooms-api.ts
@@ -204,7 +204,7 @@ export async function fetchRoomVoiceCredentials(
   token: string
 ): Promise<RoomVoiceCredentialsResponse> {
   const response = await fetch(`${API_BASE_URL}/rooms/${roomID}/voice/credentials`, {
-    method: "GET",
+    method: "POST",
     headers: headers(token),
   });
   if (!response.ok) {


### PR DESCRIPTION
## Summary

Add room tile focus/fullscreen interactions and speaking indicators for room voice sessions.

## Changes

- add room tile focus mode with a bottom strip of the remaining tiles
- add fullscreen toggle for camera and screen-share tiles
- render screen share as a separate tile without replacing the participant tile
- add speaking indicators for participant tiles and screen-share tiles
- align room voice client flow with the POST `/api/rooms/:id/voice/credentials` endpoint

## Verification

- `npm run build`
- local browser regression pass for login, friends, chat, rooms, join/leave voice, camera, and screen share
- verified focus mode and fullscreen interactions locally

## Known Issue

- after stopping screen share, remote participants can still briefly retain an empty black screen-share tile; this is not fixed in this PR yet
